### PR TITLE
[FEAT] 다른 서비스와 응답 포멧 일치화, provider 수정, MVP 테스트용 matchsecurityconfig 활성화

### DIFF
--- a/src/main/java/org/ticketing/match/application/service/MatchApplicationService.java
+++ b/src/main/java/org/ticketing/match/application/service/MatchApplicationService.java
@@ -45,7 +45,6 @@ import org.ticketing.match.domain.service.StadiumProvider;
  * Feign 호출 분기가 추가될 예정이다.
  */
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MatchApplicationService {
 
@@ -62,9 +61,8 @@ public class MatchApplicationService {
     /**
      * 경기 생성.
      *
-     * <p>메서드 레벨에 {@code @Transactional} 을 선언하지 않는다.
-     * 클래스 레벨 {@code readOnly = true} 트랜잭션도 이 메서드 실행 중에는
-     * JPA 작업이 없으므로 실질적으로 커넥션을 점유하지 않는다.
+     * <p>트랜잭션 없이 외부 서비스 검증을 먼저 수행한다.
+     * Feign 호출 동안 DB 커넥션을 점유하지 않으며,
      * Feign 호출이 끝난 뒤 {@link MatchWriteService#create}가 새 트랜잭션을 열어
      * 모든 쓰기를 원자적으로 처리한다.
      */
@@ -99,6 +97,7 @@ public class MatchApplicationService {
     // 조회
     // ──────────────────────────────────────────
 
+    @Transactional(readOnly = true)
     public MatchResult findMatch(FindMatchQuery query) {
         Match match = matchRepository.findActiveById(query.matchId())
                 .orElseThrow(() -> new MatchNotFoundException(query.matchId()));
@@ -127,8 +126,7 @@ public class MatchApplicationService {
     /**
      * ZonePolicy 추가.
      *
-     * <p>{@code createMatch} 와 동일하게 메서드 레벨 {@code @Transactional} 을 두지 않는다.
-     * SeatGrade 존재 검증을 Feign 으로 수행한 뒤 {@link MatchWriteService#addZonePolicy} 에
+     * <p>SeatGrade 존재 검증을 Feign 으로 수행한 뒤 {@link MatchWriteService#addZonePolicy} 에
      * 쓰기를 위임하므로, Feign 호출 동안 DB 커넥션을 점유하지 않는다.
      */
     public MatchZonePolicyResult addZonePolicy(AddMatchZonePolicyCommand command) {

--- a/src/main/java/org/ticketing/match/infrastructure/client/ClubClient.java
+++ b/src/main/java/org/ticketing/match/infrastructure/client/ClubClient.java
@@ -4,10 +4,14 @@ import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.ticketing.match.infrastructure.client.dto.CommonResponse;
 
 @FeignClient(name = "club-service")
 public interface ClubClient {
 
     @GetMapping("/internal/clubs/{clubId}/exists")
-    boolean existsById(@PathVariable UUID clubId);
+    CommonResponse<Boolean> existsClub(@PathVariable("clubId") UUID clubId);
+
+    @GetMapping("/internal/stadiums/{stadiumId}/exists")
+    CommonResponse<Boolean> existsStadium(@PathVariable("stadiumId") UUID stadiumId);
 }

--- a/src/main/java/org/ticketing/match/infrastructure/client/SeatGradeClient.java
+++ b/src/main/java/org/ticketing/match/infrastructure/client/SeatGradeClient.java
@@ -4,10 +4,11 @@ import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.ticketing.match.infrastructure.client.dto.CommonResponse;
 
 @FeignClient(name = "seat-service", contextId = "seatGradeClient")
 public interface SeatGradeClient {
 
     @GetMapping("/internal/seat-grades/{seatGradeId}/exists")
-    boolean existsById(@PathVariable UUID seatGradeId);
+    CommonResponse<Boolean> existsById(@PathVariable("seatGradeId") UUID seatGradeId);
 }

--- a/src/main/java/org/ticketing/match/infrastructure/client/dto/CommonResponse.java
+++ b/src/main/java/org/ticketing/match/infrastructure/client/dto/CommonResponse.java
@@ -1,0 +1,9 @@
+package org.ticketing.match.infrastructure.client.dto;
+
+public record CommonResponse<T>(
+        boolean success,
+        String message,
+        T data,
+        String traceId
+) {
+}

--- a/src/main/java/org/ticketing/match/infrastructure/config/MatchSecurityConfig.java
+++ b/src/main/java/org/ticketing/match/infrastructure/config/MatchSecurityConfig.java
@@ -1,0 +1,31 @@
+package org.ticketing.match.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class MatchSecurityConfig {
+
+    // MVP 통합 테스트용 임시 SecurityConfig
+    @Bean
+    @Order(1)
+    public SecurityFilterChain matchFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .securityMatcher("/**")
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                )
+                .build();
+    }
+}

--- a/src/main/java/org/ticketing/match/infrastructure/provider/ClubProviderImpl.java
+++ b/src/main/java/org/ticketing/match/infrastructure/provider/ClubProviderImpl.java
@@ -14,6 +14,6 @@ public class ClubProviderImpl implements ClubProvider {
 
     @Override
     public boolean existsById(UUID clubId) {
-        return clubClient.existsById(clubId);
+        return Boolean.TRUE.equals(clubClient.existsClub(clubId).data());
     }
 }

--- a/src/main/java/org/ticketing/match/infrastructure/provider/SeatGradeProviderImpl.java
+++ b/src/main/java/org/ticketing/match/infrastructure/provider/SeatGradeProviderImpl.java
@@ -14,6 +14,6 @@ public class SeatGradeProviderImpl implements SeatGradeProvider {
 
     @Override
     public boolean existsById(UUID seatGradeId) {
-        return seatGradeClient.existsById(seatGradeId);
+        return Boolean.TRUE.equals(seatGradeClient.existsById(seatGradeId).data());
     }
 }

--- a/src/main/java/org/ticketing/match/infrastructure/provider/StadiumProviderImpl.java
+++ b/src/main/java/org/ticketing/match/infrastructure/provider/StadiumProviderImpl.java
@@ -4,16 +4,16 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.ticketing.match.domain.service.StadiumProvider;
-import org.ticketing.match.infrastructure.client.StadiumClient;
+import org.ticketing.match.infrastructure.client.ClubClient;
 
 @Component
 @RequiredArgsConstructor
 public class StadiumProviderImpl implements StadiumProvider {
 
-    private final StadiumClient stadiumClient;
+    private final ClubClient clubClient;
 
     @Override
     public boolean existsById(UUID stadiumId) {
-        return stadiumClient.existsById(stadiumId);
+        return Boolean.TRUE.equals(clubClient.existsStadium(stadiumId).data());
     }
 }

--- a/src/main/java/org/ticketing/match/infrastructure/security/WebSecurityConfig.java
+++ b/src/main/java/org/ticketing/match/infrastructure/security/WebSecurityConfig.java
@@ -36,9 +36,10 @@ import org.ticketing.config.security.LoginFilter;
  *   <li>그 외 — 인증 필요 (JWT 검증)</li>
  * </ul>
  */
-@Configuration
-@EnableWebSecurity
-@EnableMethodSecurity
+// MVP 통합 테스트 기간 동안 MatchSecurityConfig (infrastructure/config) 로 대체됨
+// @Configuration
+// @EnableWebSecurity
+// @EnableMethodSecurity
 public class WebSecurityConfig {
 
     /**


### PR DESCRIPTION
### 📎 관련 이슈
- close #이슈번호

###📌 작업 내용

match-service Feign 클라이언트 응답 타입을 CommonResponse<T> 래퍼로 통일
StadiumProviderImpl이 별도 StadiumClient 대신 ClubClient를 사용하도록 수정
MatchApplicationService 트랜잭션 애노테이션을 메서드 단위로 분리
MVP 통합 테스트용 임시 MatchSecurityConfig 추가 및 기존 WebSecurityConfig 비활성화

###✨ 변경 사항

CommonResponse<T> 레코드 신규 생성 (infrastructure/client/dto)
ClubClient — 반환 타입 boolean → CommonResponse<Boolean>, stadium exists 엔드포인트 추가
SeatGradeClient — 반환 타입 boolean → CommonResponse<Boolean>
ClubProviderImpl, StadiumProviderImpl, SeatGradeProviderImpl — .data() 언래핑 처리
StadiumProviderImpl — StadiumClient 의존성 제거, ClubClient 재사용
MatchApplicationService — 클래스 레벨 @Transactional(readOnly = true) 제거, 조회 메서드에 readOnly = true, 쓰기 메서드에 @Transactional 개별 부여
MatchSecurityConfig 신규 생성 — anyRequest().permitAll() (MVP 테스트용 임시 설정)
WebSecurityConfig — @Configuration 주석 처리로 비활성화 (SecurityFilterChain 중복 등록 문제 해결)

### 📝 리뷰 포인트 (선택)
- 집중해서 봐줬으면 하는 부분

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)