### PR TITLE
[FEAT] match-service 구역별 실시간 잔여 좌석 수 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,9 @@ dependencies {
 
 	runtimeOnly 'org.springframework.boot:spring-boot-starter-actuator'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/ticketing/match/application/dto/result/RemainingSeatsResult.java
+++ b/src/main/java/org/ticketing/match/application/dto/result/RemainingSeatsResult.java
@@ -1,0 +1,20 @@
+package org.ticketing.match.application.dto.result;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 경기의 구역별 실시간 잔여 좌석 수 조회 결과.
+ */
+public record RemainingSeatsResult(
+        UUID matchId,
+        List<ZoneAvailability> zones
+) {
+
+    public record ZoneAvailability(
+            UUID seatGradeId,
+            Long price,
+            Long totalSeatCount,
+            Long remainingCount
+    ) {}
+}

--- a/src/main/java/org/ticketing/match/application/service/MatchApplicationService.java
+++ b/src/main/java/org/ticketing/match/application/service/MatchApplicationService.java
@@ -1,5 +1,8 @@
 package org.ticketing.match.application.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,12 +16,16 @@ import org.ticketing.match.application.dto.command.UpdateMatchZonePolicyCommand;
 import org.ticketing.match.application.dto.query.FindMatchQuery;
 import org.ticketing.match.application.dto.result.MatchResult;
 import org.ticketing.match.application.dto.result.MatchZonePolicyResult;
+import org.ticketing.match.application.dto.result.RemainingSeatsResult;
+import org.ticketing.match.application.dto.result.RemainingSeatsResult.ZoneAvailability;
 import org.ticketing.match.domain.exception.ClubNotFoundException;
 import org.ticketing.match.domain.exception.MatchNotFoundException;
 import org.ticketing.match.domain.exception.SeatGradeNotFoundException;
 import org.ticketing.match.domain.exception.StadiumNotFoundException;
 import org.ticketing.match.domain.model.Match;
+import org.ticketing.match.domain.model.MatchZonePolicy;
 import org.ticketing.match.domain.repository.MatchRepository;
+import org.ticketing.match.domain.repository.SeatAvailabilityRepository;
 import org.ticketing.match.domain.service.ClubProvider;
 import org.ticketing.match.domain.service.SeatGradeProvider;
 import org.ticketing.match.domain.service.StadiumProvider;
@@ -54,6 +61,7 @@ public class MatchApplicationService {
     private final ClubProvider clubProvider;
     private final StadiumProvider stadiumProvider;
     private final SeatGradeProvider seatGradeProvider;
+    private final SeatAvailabilityRepository seatAvailabilityRepository;
 
     // ──────────────────────────────────────────
     // Match 생성 — Feign 검증 후 커맨드 서비스에 위임
@@ -105,6 +113,32 @@ public class MatchApplicationService {
         return MatchResult.from(match);
     }
 
+    /**
+     * 경기의 구역별 실시간 잔여 좌석 수 조회.
+     *
+     * <p>Redis Hash 에서 잔여 좌석 수를 읽고, DB 의 ZonePolicy(가격·총 좌석 수) 와 조인하여 반환한다.
+     * Redis 캐시가 없는 구역은 totalSeatCount 를 remainingCount 로 대체한다
+     * (APPROVED 전 조회 등 초기화 전 상태 방어).
+     */
+    public RemainingSeatsResult getRemainingSeats(UUID matchId) {
+        Match match = matchRepository.findActiveById(matchId)
+                .orElseThrow(() -> new MatchNotFoundException(matchId));
+
+        Map<UUID, Long> remaining = seatAvailabilityRepository.findAll(matchId);
+
+        List<ZoneAvailability> zones = match.getZonePolicies().stream()
+                .filter(p -> p.getDeletedAt() == null)
+                .map(p -> new ZoneAvailability(
+                        p.getSeatGradeId(),
+                        p.getPrice(),
+                        p.getTotalSeatCount(),
+                        remaining.getOrDefault(p.getSeatGradeId(), p.getTotalSeatCount())
+                ))
+                .toList();
+
+        return new RemainingSeatsResult(matchId, zones);
+    }
+
     // ──────────────────────────────────────────
     // 쓰기 위임 — MatchCommandService
     // ──────────────────────────────────────────
@@ -135,7 +169,9 @@ public class MatchApplicationService {
         if (!seatGradeProvider.existsById(command.seatGradeId())) {
             throw new SeatGradeNotFoundException(command.seatGradeId());
         }
-        return matchWriteService.addZonePolicy(command);
+        // seat-service 에서 해당 구역의 총 좌석 수를 조회하여 ZonePolicy 생성 시 함께 저장
+        long totalSeatCount = seatGradeProvider.countBySeatGradeId(command.seatGradeId());
+        return matchWriteService.addZonePolicy(command, totalSeatCount);
     }
 
     @Transactional

--- a/src/main/java/org/ticketing/match/application/service/MatchApplicationService.java
+++ b/src/main/java/org/ticketing/match/application/service/MatchApplicationService.java
@@ -118,7 +118,11 @@ public class MatchApplicationService {
      * <p>Redis Hash 에서 잔여 좌석 수를 읽고, DB 의 ZonePolicy(가격·총 좌석 수) 와 조인하여 반환한다.
      * Redis 캐시가 없는 구역은 totalSeatCount 를 remainingCount 로 대체한다
      * (APPROVED 전 조회 등 초기화 전 상태 방어).
+     *
+     * <p>{@code @Transactional(readOnly = true)} 를 선언하여 {@code match.getZonePolicies()} 지연 로딩 시
+     * Hibernate 세션이 열려 있도록 보장한다. 없으면 {@link org.hibernate.LazyInitializationException} 발생.
      */
+    @Transactional(readOnly = true)
     public RemainingSeatsResult getRemainingSeats(UUID matchId) {
         Match match = matchRepository.findActiveById(matchId)
                 .orElseThrow(() -> new MatchNotFoundException(matchId));

--- a/src/main/java/org/ticketing/match/application/service/MatchWriteService.java
+++ b/src/main/java/org/ticketing/match/application/service/MatchWriteService.java
@@ -1,7 +1,11 @@
 package org.ticketing.match.application.service;
 
 import java.time.OffsetDateTime;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +25,7 @@ import org.ticketing.match.domain.model.Match;
 import org.ticketing.match.domain.model.MatchStatus;
 import org.ticketing.match.domain.model.MatchZonePolicy;
 import org.ticketing.match.domain.repository.MatchRepository;
+import org.ticketing.match.domain.repository.SeatAvailabilityRepository;
 
 /**
  * Match 어그리게이트 쓰기 전담 서비스.
@@ -42,6 +47,7 @@ public class MatchWriteService {
 
     private final MatchRepository matchRepository;
     private final MatchEventPublisher matchEventPublisher;
+    private final SeatAvailabilityRepository seatAvailabilityRepository;
 
     // ──────────────────────────────────────────
     // Match 생성
@@ -77,6 +83,20 @@ public class MatchWriteService {
             matchEventPublisher.publishMatchApproved(
                     new MatchApprovedEvent(match.getId(), match.getTicketOpenAt())
             );
+            // APPROVED 전환 시 Redis 잔여 좌석 초기화 — DB 커밋 후 실행하여 정합성 보장
+            Map<UUID, Long> seatCounts = match.getZonePolicies().stream()
+                    .filter(p -> p.getDeletedAt() == null)
+                    .collect(Collectors.toMap(
+                            MatchZonePolicy::getSeatGradeId,
+                            MatchZonePolicy::getTotalSeatCount
+                    ));
+            UUID matchId = match.getId();
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    seatAvailabilityRepository.initialize(matchId, seatCounts);
+                }
+            });
         } else if (command.targetStatus() == MatchStatus.CANCELED) {
             matchEventPublisher.publishMatchCanceled(
                     new MatchCanceledEvent(match.getId(), OffsetDateTime.now())
@@ -95,9 +115,9 @@ public class MatchWriteService {
     // ZonePolicy
     // ──────────────────────────────────────────
 
-    public MatchZonePolicyResult addZonePolicy(AddMatchZonePolicyCommand command) {
+    public MatchZonePolicyResult addZonePolicy(AddMatchZonePolicyCommand command, long totalSeatCount) {
         Match match = getActive(command.matchId());
-        MatchZonePolicy policy = match.addZonePolicy(command.seatGradeId(), command.price());
+        MatchZonePolicy policy = match.addZonePolicy(command.seatGradeId(), command.price(), totalSeatCount);
         matchRepository.saveAndFlush(match);
         return MatchZonePolicyResult.from(policy);
     }

--- a/src/main/java/org/ticketing/match/application/service/MatchWriteService.java
+++ b/src/main/java/org/ticketing/match/application/service/MatchWriteService.java
@@ -4,6 +4,7 @@ import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +41,7 @@ import org.ticketing.match.domain.repository.SeatAvailabilityRepository;
  *   <li>트랜잭션 커밋 후 {@code OutboxEventListener.publish()} 가 Kafka 로 전송</li>
  * </ol>
  */
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -84,17 +86,37 @@ public class MatchWriteService {
                     new MatchApprovedEvent(match.getId(), match.getTicketOpenAt())
             );
             // APPROVED 전환 시 Redis 잔여 좌석 초기화 — DB 커밋 후 실행하여 정합성 보장
+            //
+            // merge function: 동일 seatGradeId 를 가진 활성 ZonePolicy 가 둘 이상이면
+            // 도메인 불변식 위반이므로 경고 로그를 남기고 첫 번째 값을 사용한다.
+            UUID matchId = match.getId();
             Map<UUID, Long> seatCounts = match.getZonePolicies().stream()
                     .filter(p -> p.getDeletedAt() == null)
                     .collect(Collectors.toMap(
                             MatchZonePolicy::getSeatGradeId,
-                            MatchZonePolicy::getTotalSeatCount
+                            MatchZonePolicy::getTotalSeatCount,
+                            (existing, duplicate) -> {
+                                log.warn("[MatchWriteService] matchId={} — seatGradeId 중복 ZonePolicy 감지. "
+                                        + "도메인 불변식 위반 가능성. 첫 번째 값({}) 사용.", matchId, existing);
+                                return existing;
+                            }
                     ));
-            UUID matchId = match.getId();
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
-                    seatAvailabilityRepository.initialize(matchId, seatCounts);
+                    // Redis 초기화 실패 시 match 는 이미 APPROVED 로 커밋된 상태.
+                    // 실패를 에러 로그로 기록하여 운영 알람 및 수동 재초기화가 가능하도록 한다.
+                    // fallback: getRemainingSeats() 는 Redis 가 비어 있으면 totalSeatCount 를 반환하므로
+                    // 서비스 중단은 없지만 실시간 카운트 정확도가 떨어진다.
+                    try {
+                        seatAvailabilityRepository.initialize(matchId, seatCounts);
+                        log.info("[MatchWriteService] matchId={} Redis 잔여 좌석 초기화 완료. zones={}",
+                                matchId, seatCounts.size());
+                    } catch (Exception e) {
+                        log.error("[MatchWriteService] matchId={} Redis 잔여 좌석 초기화 실패. "
+                                + "APPROVED 커밋은 완료됐으나 Redis 가 비어 있음. "
+                                + "수동 재초기화 또는 재승인 처리 필요.", matchId, e);
+                    }
                 }
             });
         } else if (command.targetStatus() == MatchStatus.CANCELED) {

--- a/src/main/java/org/ticketing/match/domain/model/Match.java
+++ b/src/main/java/org/ticketing/match/domain/model/Match.java
@@ -121,7 +121,7 @@ public class Match extends BaseEntity {
     // ──────────────────────────────────────────
 
     // 동일 seatGradeId 정책은 삭제 여부와 무관하게 재등록 불가 (기록 보존 정책)
-    public MatchZonePolicy addZonePolicy(UUID seatGradeId, Long price) {
+    public MatchZonePolicy addZonePolicy(UUID seatGradeId, Long price, Long totalSeatCount) {
 
         boolean exists = zonePolicies.stream()
                 .anyMatch(p -> p.getSeatGradeId().equals(seatGradeId));
@@ -129,7 +129,7 @@ public class Match extends BaseEntity {
             throw new DuplicateMatchZonePolicyException(id, seatGradeId);
         }
         MatchZonePolicy policy =
-                MatchZonePolicy.create(this, seatGradeId, price);
+                MatchZonePolicy.create(this, seatGradeId, price, totalSeatCount);
         zonePolicies.add(policy);
         return policy;
     }

--- a/src/main/java/org/ticketing/match/domain/model/MatchZonePolicy.java
+++ b/src/main/java/org/ticketing/match/domain/model/MatchZonePolicy.java
@@ -43,12 +43,17 @@ public class MatchZonePolicy extends BaseEntity {
     @Column(name = "is_open", nullable = false)
     private Boolean isOpen;
 
-    static MatchZonePolicy create(Match match, UUID seatGradeId, Long price) {
+    /** seat-service 에서 조회한 해당 구역 총 좌석 수. Redis 잔여 좌석 초기화 소스로 사용. */
+    @Column(name = "total_seat_count", nullable = false)
+    private Long totalSeatCount;
+
+    static MatchZonePolicy create(Match match, UUID seatGradeId, Long price, Long totalSeatCount) {
         MatchZonePolicy policy = new MatchZonePolicy();
         policy.match = match;
         policy.seatGradeId = seatGradeId;
         policy.price = price;
         policy.isOpen = false;
+        policy.totalSeatCount = totalSeatCount;
         return policy;
     }
 

--- a/src/main/java/org/ticketing/match/domain/repository/SeatAvailabilityRepository.java
+++ b/src/main/java/org/ticketing/match/domain/repository/SeatAvailabilityRepository.java
@@ -1,0 +1,49 @@
+package org.ticketing.match.domain.repository;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 구역별 실시간 잔여 좌석 수를 관리하는 도메인 레포지토리 인터페이스.
+ *
+ * <p>Redis Hash 를 구현체로 사용한다.
+ * <ul>
+ *   <li>key   : {@code seat:remaining:{matchId}}</li>
+ *   <li>field : seatGradeId (문자열)</li>
+ *   <li>value : 잔여 좌석 수</li>
+ * </ul>
+ */
+public interface SeatAvailabilityRepository {
+
+    /**
+     * 경기 승인 시 구역별 잔여 좌석 수를 초기화한다.
+     *
+     * @param matchId         경기 ID
+     * @param seatCountByGrade seatGradeId → totalSeatCount 맵
+     */
+    void initialize(UUID matchId, Map<UUID, Long> seatCountByGrade);
+
+    /**
+     * 좌석 예매 시 해당 구역의 잔여 좌석 수를 1 감소시킨다.
+     *
+     * @param matchId     경기 ID
+     * @param seatGradeId 좌석 등급 ID
+     */
+    void decrement(UUID matchId, UUID seatGradeId);
+
+    /**
+     * 예매 취소/해제 시 해당 구역의 잔여 좌석 수를 1 증가시킨다.
+     *
+     * @param matchId     경기 ID
+     * @param seatGradeId 좌석 등급 ID
+     */
+    void increment(UUID matchId, UUID seatGradeId);
+
+    /**
+     * 경기의 모든 구역 잔여 좌석 수를 조회한다.
+     *
+     * @param matchId 경기 ID
+     * @return seatGradeId → 잔여 좌석 수 맵 (캐시 미존재 시 빈 맵)
+     */
+    Map<UUID, Long> findAll(UUID matchId);
+}

--- a/src/main/java/org/ticketing/match/domain/service/SeatGradeProvider.java
+++ b/src/main/java/org/ticketing/match/domain/service/SeatGradeProvider.java
@@ -6,4 +6,6 @@ import java.util.UUID;
 public interface SeatGradeProvider {
 
     boolean existsById(UUID seatGradeId);
+
+    long countBySeatGradeId(UUID seatGradeId);
 }

--- a/src/main/java/org/ticketing/match/infrastructure/client/SeatGradeClient.java
+++ b/src/main/java/org/ticketing/match/infrastructure/client/SeatGradeClient.java
@@ -10,4 +10,7 @@ public interface SeatGradeClient {
 
     @GetMapping("/internal/seat-grades/{seatGradeId}/exists")
     boolean existsById(@PathVariable UUID seatGradeId);
+
+    @GetMapping("/internal/seat-grades/{seatGradeId}/count")
+    long countBySeatGradeId(@PathVariable UUID seatGradeId);
 }

--- a/src/main/java/org/ticketing/match/infrastructure/client/SeatGradeClient.java
+++ b/src/main/java/org/ticketing/match/infrastructure/client/SeatGradeClient.java
@@ -11,4 +11,7 @@ public interface SeatGradeClient {
 
     @GetMapping("/internal/seat-grades/{seatGradeId}/exists")
     CommonResponse<Boolean> existsById(@PathVariable("seatGradeId") UUID seatGradeId);
+
+    @GetMapping("/internal/seat-grades/{seatGradeId}/count")
+    CommonResponse<Long> countBySeatGradeId(@PathVariable("seatGradeId") UUID seatGradeId);
 }

--- a/src/main/java/org/ticketing/match/infrastructure/config/KafkaConsumerConfig.java
+++ b/src/main/java/org/ticketing/match/infrastructure/config/KafkaConsumerConfig.java
@@ -1,0 +1,91 @@
+package org.ticketing.match.infrastructure.config;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+/**
+ * Kafka 컨슈머 컨테이너 팩토리 설정.
+ *
+ * <h3>신뢰성 정책</h3>
+ * <ul>
+ *   <li><b>AckMode.RECORD</b>: 레코드 처리 완료 후 오프셋을 수동 커밋.
+ *       auto-commit(=true) 이면 처리 실패 시에도 오프셋이 커밋되어 메시지 유실.</li>
+ *   <li><b>재시도 3회</b>: 1초 간격 고정 백오프(transient Redis 오류 등 일시적 장애 대응).</li>
+ *   <li><b>Dead Letter Topic</b>: 3회 재시도 후에도 실패하면 {@code {topic}.DLT} 로 이동.
+ *       DLT 파티션은 원본과 동일하게 유지하여 순서 추적 용이.</li>
+ *   <li><b>JsonProcessingException 즉시 DLT</b>: 역직렬화 오류는 재시도해도 해결되지 않으므로
+ *       즉시 DLT 로 보내 컨슈머 lag 증가를 방지.</li>
+ * </ul>
+ *
+ * <p>{@code ConsumerFactory} 와 {@code KafkaTemplate} 은 Spring Boot 자동 구성에서 주입받으며,
+ * {@code application.yaml} 의 {@code spring.kafka.consumer.*} 설정이 함께 적용된다.
+ */
+@Slf4j
+@Configuration
+public class KafkaConsumerConfig {
+
+    /**
+     * 일시적 장애(Redis 지연 등)를 고려한 재시도 횟수.
+     * 1초 × 3회 → 최대 3초 후 DLT 전송.
+     */
+    private static final long RETRY_INTERVAL_MS = 1_000L;
+    private static final long MAX_RETRY_ATTEMPTS = 3L;
+
+    /**
+     * Kafka 컨슈머 리스너 팩토리.
+     *
+     * <p>Spring Boot 자동 구성의 기본 {@code kafkaListenerContainerFactory} 빈을 대체한다.
+     * {@code ConsumerFactory} 는 {@code spring.kafka.consumer.*} 설정을 기반으로
+     * Spring Boot 가 자동 구성한 빈을 그대로 사용한다.
+     *
+     * @param consumerFactory Spring Boot 자동 구성 ConsumerFactory
+     * @param kafkaTemplate   DLT 발행용 KafkaTemplate
+     */
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+            ConsumerFactory<String, String> consumerFactory,
+            KafkaTemplate<String, String> kafkaTemplate
+    ) {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory);
+
+        // 레코드 단위 수동 커밋 — 처리 완료 후 오프셋 커밋하여 메시지 유실 방지
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.RECORD);
+
+        // DLT 복구 전략: 원본 토픽명 + ".DLT", 동일 파티션으로 전송
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
+                kafkaTemplate,
+                (record, ex) -> {
+                    log.error(
+                            "[KafkaConsumer] DLT 전송 — topic={}.DLT, partition={}, offset={}, cause={}",
+                            record.topic(), record.partition(), record.offset(),
+                            ex.getMessage()
+                    );
+                    return new TopicPartition(record.topic() + ".DLT", record.partition());
+                }
+        );
+
+        // 3회 재시도 (1초 고정 간격) 후 DLT
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(
+                recoverer,
+                new FixedBackOff(RETRY_INTERVAL_MS, MAX_RETRY_ATTEMPTS)
+        );
+
+        // 역직렬화 오류는 재시도로 해결 불가 → 즉시 DLT 전송
+        errorHandler.addNotRetryableExceptions(JsonProcessingException.class);
+
+        factory.setCommonErrorHandler(errorHandler);
+        return factory;
+    }
+}

--- a/src/main/java/org/ticketing/match/infrastructure/config/KafkaTopicConfig.java
+++ b/src/main/java/org/ticketing/match/infrastructure/config/KafkaTopicConfig.java
@@ -66,4 +66,26 @@ public class KafkaTopicConfig {
                 .replicas(replicas)
                 .build();
     }
+
+    // ──────────────────────────────────────────
+    // Dead Letter Topics (DLT)
+    // 처리 실패 메시지가 3회 재시도 후 전송되는 토픽.
+    // 파티션 수는 원본 토픽과 동일하게 유지하여 오프셋 추적 용이.
+    // ──────────────────────────────────────────
+
+    @Bean
+    public NewTopic reservationSeatReservedDltTopic() {
+        return TopicBuilder.name(reservationSeatReservedTopic + ".DLT")
+                .partitions(partitions)
+                .replicas(replicas)
+                .build();
+    }
+
+    @Bean
+    public NewTopic reservationSeatReleasedDltTopic() {
+        return TopicBuilder.name(reservationSeatReleasedTopic + ".DLT")
+                .partitions(partitions)
+                .replicas(replicas)
+                .build();
+    }
 }

--- a/src/main/java/org/ticketing/match/infrastructure/config/KafkaTopicConfig.java
+++ b/src/main/java/org/ticketing/match/infrastructure/config/KafkaTopicConfig.java
@@ -29,6 +29,12 @@ public class KafkaTopicConfig {
     @Value("${topics.match.canceled:match.canceled}")
     private String matchCanceledTopic;
 
+    @Value("${topics.reservation.seat.reserved:reservation.seat.reserved}")
+    private String reservationSeatReservedTopic;
+
+    @Value("${topics.reservation.seat.released:reservation.seat.released}")
+    private String reservationSeatReleasedTopic;
+
     @Bean
     public NewTopic matchApprovedTopic() {
         return TopicBuilder.name(matchApprovedTopic)
@@ -40,6 +46,22 @@ public class KafkaTopicConfig {
     @Bean
     public NewTopic matchCanceledTopic() {
         return TopicBuilder.name(matchCanceledTopic)
+                .partitions(partitions)
+                .replicas(replicas)
+                .build();
+    }
+
+    @Bean
+    public NewTopic reservationSeatReservedTopic() {
+        return TopicBuilder.name(reservationSeatReservedTopic)
+                .partitions(partitions)
+                .replicas(replicas)
+                .build();
+    }
+
+    @Bean
+    public NewTopic reservationSeatReleasedTopic() {
+        return TopicBuilder.name(reservationSeatReleasedTopic)
                 .partitions(partitions)
                 .replicas(replicas)
                 .build();

--- a/src/main/java/org/ticketing/match/infrastructure/event/ReservationSeatEventConsumer.java
+++ b/src/main/java/org/ticketing/match/infrastructure/event/ReservationSeatEventConsumer.java
@@ -1,5 +1,6 @@
 package org.ticketing.match.infrastructure.event;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +19,14 @@ import org.ticketing.match.infrastructure.event.payload.ReservationSeatReservedE
  *   <li>{@code reservation.seat.reserved} → {@link SeatAvailabilityRepository#decrement}</li>
  *   <li>{@code reservation.seat.released} → {@link SeatAvailabilityRepository#increment}</li>
  * </ul>
+ *
+ * <h3>오류 처리</h3>
+ * <p>예외를 catch 하지 않고 전파하여 {@link KafkaConsumerConfig} 의 {@code DefaultErrorHandler} 가
+ * 처리하도록 한다.
+ * <ul>
+ *   <li>{@link JsonProcessingException}: non-retryable — 즉시 {@code {topic}.DLT} 로 이동</li>
+ *   <li>Redis 오류 등 런타임 예외: 1초 간격 3회 재시도 후 DLT 로 이동</li>
+ * </ul>
  */
 @Slf4j
 @Component
@@ -32,15 +41,11 @@ public class ReservationSeatEventConsumer {
             groupId = "${spring.kafka.consumer.group-id:match-service}",
             containerFactory = "kafkaListenerContainerFactory"
     )
-    public void onSeatReserved(ConsumerRecord<String, String> record) {
-        try {
-            ReservationSeatReservedEvent event =
-                    objectMapper.readValue(record.value(), ReservationSeatReservedEvent.class);
-            log.debug("[SeatEvent] reserved matchId={}, seatGradeId={}", event.matchId(), event.seatGradeId());
-            seatAvailabilityRepository.decrement(event.matchId(), event.seatGradeId());
-        } catch (Exception e) {
-            log.error("[SeatEvent] failed to process reserved event: {}", record.value(), e);
-        }
+    public void onSeatReserved(ConsumerRecord<String, String> record) throws JsonProcessingException {
+        ReservationSeatReservedEvent event =
+                objectMapper.readValue(record.value(), ReservationSeatReservedEvent.class);
+        log.debug("[SeatEvent] reserved matchId={}, seatGradeId={}", event.matchId(), event.seatGradeId());
+        seatAvailabilityRepository.decrement(event.matchId(), event.seatGradeId());
     }
 
     @KafkaListener(
@@ -48,14 +53,11 @@ public class ReservationSeatEventConsumer {
             groupId = "${spring.kafka.consumer.group-id:match-service}",
             containerFactory = "kafkaListenerContainerFactory"
     )
-    public void onSeatReleased(ConsumerRecord<String, String> record) {
-        try {
-            ReservationSeatReleasedEvent event =
-                    objectMapper.readValue(record.value(), ReservationSeatReleasedEvent.class);
-            log.debug("[SeatEvent] released matchId={}, seatGradeId={}, reason={}", event.matchId(), event.seatGradeId(), event.reason());
-            seatAvailabilityRepository.increment(event.matchId(), event.seatGradeId());
-        } catch (Exception e) {
-            log.error("[SeatEvent] failed to process released event: {}", record.value(), e);
-        }
+    public void onSeatReleased(ConsumerRecord<String, String> record) throws JsonProcessingException {
+        ReservationSeatReleasedEvent event =
+                objectMapper.readValue(record.value(), ReservationSeatReleasedEvent.class);
+        log.debug("[SeatEvent] released matchId={}, seatGradeId={}, reason={}",
+                event.matchId(), event.seatGradeId(), event.reason());
+        seatAvailabilityRepository.increment(event.matchId(), event.seatGradeId());
     }
 }

--- a/src/main/java/org/ticketing/match/infrastructure/event/ReservationSeatEventConsumer.java
+++ b/src/main/java/org/ticketing/match/infrastructure/event/ReservationSeatEventConsumer.java
@@ -1,0 +1,61 @@
+package org.ticketing.match.infrastructure.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.ticketing.match.domain.repository.SeatAvailabilityRepository;
+import org.ticketing.match.infrastructure.event.payload.ReservationSeatReleasedEvent;
+import org.ticketing.match.infrastructure.event.payload.ReservationSeatReservedEvent;
+
+/**
+ * reservation-service 에서 발행하는 좌석 예매/해제 이벤트를 소비하여
+ * Redis 잔여 좌석 카운터를 갱신하는 Kafka 컨슈머.
+ *
+ * <ul>
+ *   <li>{@code reservation.seat.reserved} → {@link SeatAvailabilityRepository#decrement}</li>
+ *   <li>{@code reservation.seat.released} → {@link SeatAvailabilityRepository#increment}</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationSeatEventConsumer {
+
+    private final SeatAvailabilityRepository seatAvailabilityRepository;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = "${topics.reservation.seat.reserved:reservation.seat.reserved}",
+            groupId = "${spring.kafka.consumer.group-id:match-service}",
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void onSeatReserved(ConsumerRecord<String, String> record) {
+        try {
+            ReservationSeatReservedEvent event =
+                    objectMapper.readValue(record.value(), ReservationSeatReservedEvent.class);
+            log.debug("[SeatEvent] reserved matchId={}, seatGradeId={}", event.matchId(), event.seatGradeId());
+            seatAvailabilityRepository.decrement(event.matchId(), event.seatGradeId());
+        } catch (Exception e) {
+            log.error("[SeatEvent] failed to process reserved event: {}", record.value(), e);
+        }
+    }
+
+    @KafkaListener(
+            topics = "${topics.reservation.seat.released:reservation.seat.released}",
+            groupId = "${spring.kafka.consumer.group-id:match-service}",
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void onSeatReleased(ConsumerRecord<String, String> record) {
+        try {
+            ReservationSeatReleasedEvent event =
+                    objectMapper.readValue(record.value(), ReservationSeatReleasedEvent.class);
+            log.debug("[SeatEvent] released matchId={}, seatGradeId={}, reason={}", event.matchId(), event.seatGradeId(), event.reason());
+            seatAvailabilityRepository.increment(event.matchId(), event.seatGradeId());
+        } catch (Exception e) {
+            log.error("[SeatEvent] failed to process released event: {}", record.value(), e);
+        }
+    }
+}

--- a/src/main/java/org/ticketing/match/infrastructure/event/ReservationSeatEventConsumer.java
+++ b/src/main/java/org/ticketing/match/infrastructure/event/ReservationSeatEventConsumer.java
@@ -2,9 +2,11 @@ package org.ticketing.match.infrastructure.event;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.ticketing.match.domain.repository.SeatAvailabilityRepository;
@@ -27,14 +29,28 @@ import org.ticketing.match.infrastructure.event.payload.ReservationSeatReservedE
  *   <li>{@link JsonProcessingException}: non-retryable — 즉시 {@code {topic}.DLT} 로 이동</li>
  *   <li>Redis 오류 등 런타임 예외: 1초 간격 3회 재시도 후 DLT 로 이동</li>
  * </ul>
+ *
+ * <h3>멱등성</h3>
+ * <p>Kafka 는 at-least-once 전달을 보장하므로 동일 이벤트가 중복 소비될 수 있다.
+ * {@code reservationSeatId} 를 멱등성 키로 사용하여 Redis SETNX 로 중복 처리를 방지한다.
+ * <ul>
+ *   <li>키: {@code seat:event:reserved:{reservationSeatId}}, {@code seat:event:released:{reservationSeatId}}</li>
+ *   <li>TTL: 24시간 — 재시도 윈도우를 충분히 커버</li>
+ *   <li>처리 실패 시 키 롤백 → DefaultErrorHandler 재시도 시 재처리 가능</li>
+ * </ul>
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ReservationSeatEventConsumer {
 
+    private static final String IDEMPOTENCY_RESERVED_PREFIX = "seat:event:reserved:";
+    private static final String IDEMPOTENCY_RELEASED_PREFIX = "seat:event:released:";
+    private static final Duration IDEMPOTENCY_TTL = Duration.ofHours(24);
+
     private final SeatAvailabilityRepository seatAvailabilityRepository;
     private final ObjectMapper objectMapper;
+    private final StringRedisTemplate redisTemplate;
 
     @KafkaListener(
             topics = "${topics.reservation.seat.reserved:reservation.seat.reserved}",
@@ -44,8 +60,22 @@ public class ReservationSeatEventConsumer {
     public void onSeatReserved(ConsumerRecord<String, String> record) throws JsonProcessingException {
         ReservationSeatReservedEvent event =
                 objectMapper.readValue(record.value(), ReservationSeatReservedEvent.class);
+
+        String idempotencyKey = IDEMPOTENCY_RESERVED_PREFIX + event.reservationSeatId();
+        Boolean isNew = redisTemplate.opsForValue().setIfAbsent(idempotencyKey, "1", IDEMPOTENCY_TTL);
+        if (!Boolean.TRUE.equals(isNew)) {
+            log.info("[SeatEvent] 중복 이벤트 스킵 (reserved) reservationSeatId={}", event.reservationSeatId());
+            return;
+        }
+
         log.debug("[SeatEvent] reserved matchId={}, seatGradeId={}", event.matchId(), event.seatGradeId());
-        seatAvailabilityRepository.decrement(event.matchId(), event.seatGradeId());
+        try {
+            seatAvailabilityRepository.decrement(event.matchId(), event.seatGradeId());
+        } catch (Exception e) {
+            // 처리 실패 시 멱등성 키 롤백 — DefaultErrorHandler 재시도 시 재처리 가능
+            redisTemplate.delete(idempotencyKey);
+            throw e;
+        }
     }
 
     @KafkaListener(
@@ -56,8 +86,21 @@ public class ReservationSeatEventConsumer {
     public void onSeatReleased(ConsumerRecord<String, String> record) throws JsonProcessingException {
         ReservationSeatReleasedEvent event =
                 objectMapper.readValue(record.value(), ReservationSeatReleasedEvent.class);
+
+        String idempotencyKey = IDEMPOTENCY_RELEASED_PREFIX + event.reservationSeatId();
+        Boolean isNew = redisTemplate.opsForValue().setIfAbsent(idempotencyKey, "1", IDEMPOTENCY_TTL);
+        if (!Boolean.TRUE.equals(isNew)) {
+            log.info("[SeatEvent] 중복 이벤트 스킵 (released) reservationSeatId={}", event.reservationSeatId());
+            return;
+        }
+
         log.debug("[SeatEvent] released matchId={}, seatGradeId={}, reason={}",
                 event.matchId(), event.seatGradeId(), event.reason());
-        seatAvailabilityRepository.increment(event.matchId(), event.seatGradeId());
+        try {
+            seatAvailabilityRepository.increment(event.matchId(), event.seatGradeId());
+        } catch (Exception e) {
+            redisTemplate.delete(idempotencyKey);
+            throw e;
+        }
     }
 }

--- a/src/main/java/org/ticketing/match/infrastructure/event/payload/ReservationSeatReleasedEvent.java
+++ b/src/main/java/org/ticketing/match/infrastructure/event/payload/ReservationSeatReleasedEvent.java
@@ -1,0 +1,18 @@
+package org.ticketing.match.infrastructure.event.payload;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * reservation-service 가 발행하는 좌석 예매 해제 이벤트 페이로드.
+ * match-service 에서 소비하여 Redis 잔여 좌석 수를 증가시킨다.
+ */
+public record ReservationSeatReleasedEvent(
+        UUID reservationSeatId,
+        UUID reservationId,
+        UUID matchId,
+        UUID seatId,
+        UUID seatGradeId,
+        String reason,
+        OffsetDateTime releasedAt
+) {}

--- a/src/main/java/org/ticketing/match/infrastructure/event/payload/ReservationSeatReservedEvent.java
+++ b/src/main/java/org/ticketing/match/infrastructure/event/payload/ReservationSeatReservedEvent.java
@@ -1,0 +1,17 @@
+package org.ticketing.match.infrastructure.event.payload;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * reservation-service 가 발행하는 좌석 예매 완료 이벤트 페이로드.
+ * match-service 에서 소비하여 Redis 잔여 좌석 수를 감소시킨다.
+ */
+public record ReservationSeatReservedEvent(
+        UUID reservationSeatId,
+        UUID reservationId,
+        UUID matchId,
+        UUID seatId,
+        UUID seatGradeId,
+        OffsetDateTime reservedAt
+) {}

--- a/src/main/java/org/ticketing/match/infrastructure/provider/SeatGradeProviderImpl.java
+++ b/src/main/java/org/ticketing/match/infrastructure/provider/SeatGradeProviderImpl.java
@@ -19,6 +19,7 @@ public class SeatGradeProviderImpl implements SeatGradeProvider {
 
     @Override
     public long countBySeatGradeId(UUID seatGradeId) {
-        return seatGradeClient.countBySeatGradeId(seatGradeId);
+        Long count = seatGradeClient.countBySeatGradeId(seatGradeId).data();
+        return count != null ? count : 0L;
     }
 }

--- a/src/main/java/org/ticketing/match/infrastructure/provider/SeatGradeProviderImpl.java
+++ b/src/main/java/org/ticketing/match/infrastructure/provider/SeatGradeProviderImpl.java
@@ -16,4 +16,9 @@ public class SeatGradeProviderImpl implements SeatGradeProvider {
     public boolean existsById(UUID seatGradeId) {
         return seatGradeClient.existsById(seatGradeId);
     }
+
+    @Override
+    public long countBySeatGradeId(UUID seatGradeId) {
+        return seatGradeClient.countBySeatGradeId(seatGradeId);
+    }
 }

--- a/src/main/java/org/ticketing/match/infrastructure/provider/SeatGradeProviderImpl.java
+++ b/src/main/java/org/ticketing/match/infrastructure/provider/SeatGradeProviderImpl.java
@@ -2,10 +2,13 @@ package org.ticketing.match.infrastructure.provider;
 
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.ticketing.match.domain.exception.SeatGradeNotFoundException;
 import org.ticketing.match.domain.service.SeatGradeProvider;
 import org.ticketing.match.infrastructure.client.SeatGradeClient;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class SeatGradeProviderImpl implements SeatGradeProvider {
@@ -17,9 +20,21 @@ public class SeatGradeProviderImpl implements SeatGradeProvider {
         return Boolean.TRUE.equals(seatGradeClient.existsById(seatGradeId).data());
     }
 
+    /**
+     * 좌석 등급의 총 좌석 수를 조회한다.
+     *
+     * <p>응답이 null 이거나 0 이하이면 seat-service 오류 또는 잘못된 등급으로 판단하여 예외를 던진다.
+     * 0 을 그대로 반환하면 APPROVED 시 Redis 잔여 좌석이 0 으로 초기화되어
+     * 해당 구역이 즉시 매진 처리되는 심각한 부작용이 발생한다.
+     */
     @Override
     public long countBySeatGradeId(UUID seatGradeId) {
         Long count = seatGradeClient.countBySeatGradeId(seatGradeId).data();
-        return count != null ? count : 0L;
+        if (count == null || count <= 0) {
+            log.error("[SeatGradeProvider] seatGradeId={} 좌석 수 조회 실패 — count={}. "
+                    + "seat-service 응답 이상 또는 잘못된 seatGradeId.", seatGradeId, count);
+            throw new SeatGradeNotFoundException(seatGradeId);
+        }
+        return count;
     }
 }

--- a/src/main/java/org/ticketing/match/infrastructure/redis/RedisSeatAvailabilityRepository.java
+++ b/src/main/java/org/ticketing/match/infrastructure/redis/RedisSeatAvailabilityRepository.java
@@ -2,11 +2,13 @@ package org.ticketing.match.infrastructure.redis;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Repository;
 import org.ticketing.match.domain.repository.SeatAvailabilityRepository;
 
@@ -16,7 +18,17 @@ import org.ticketing.match.domain.repository.SeatAvailabilityRepository;
  * <p>Hash 키 구조: {@code seat:remaining:{matchId}}
  * <p>field: seatGradeId(UUID 문자열), value: 잔여 좌석 수(Long 문자열)
  *
- * <p>{@code HINCRBY} 를 사용하므로 decrement / increment 가 원자적으로 처리된다.
+ * <h3>음수 방지</h3>
+ * <p>{@link #decrement} 는 Lua 스크립트를 사용하여 원자적으로 0 이하 감소를 막는다.
+ * 단순 {@code HINCRBY -1} 은 중복 이벤트 / 재시도 시 음수가 될 수 있으며,
+ * 이는 비즈니스 불변식(잔여 좌석 ≥ 0) 위반이다.
+ *
+ * <h3>Lua 스크립트 반환값</h3>
+ * <ul>
+ *   <li>-1: 키 또는 필드 없음 (Redis 초기화 전 이벤트 수신)</li>
+ *   <li>0: 이미 0 이하 — 감소 무시</li>
+ *   <li>양수: 감소 후 잔여 좌석 수</li>
+ * </ul>
  */
 @Slf4j
 @Repository
@@ -24,6 +36,19 @@ import org.ticketing.match.domain.repository.SeatAvailabilityRepository;
 public class RedisSeatAvailabilityRepository implements SeatAvailabilityRepository {
 
     private static final String KEY_PREFIX = "seat:remaining:";
+
+    /**
+     * 잔여 좌석이 1 이상일 때만 원자적으로 감소.
+     * HGET → 값이 없으면 -1 반환, 0 이하면 현재값 반환, 양수면 HINCRBY -1 후 결과 반환.
+     */
+    private static final RedisScript<Long> DECREMENT_IF_POSITIVE = RedisScript.of(
+            "local v = redis.call('HGET', KEYS[1], ARGV[1])\n"
+                    + "if v == false then return -1 end\n"
+                    + "local n = tonumber(v)\n"
+                    + "if n <= 0 then return 0 end\n"
+                    + "return redis.call('HINCRBY', KEYS[1], ARGV[1], -1)",
+            Long.class
+    );
 
     private final StringRedisTemplate redisTemplate;
 
@@ -39,8 +64,20 @@ public class RedisSeatAvailabilityRepository implements SeatAvailabilityReposito
     @Override
     public void decrement(UUID matchId, UUID seatGradeId) {
         String key = buildKey(matchId);
-        Long remaining = redisTemplate.opsForHash().increment(key, seatGradeId.toString(), -1L);
-        log.debug("[SeatAvailability] decrement matchId={}, seatGradeId={}, remaining={}", matchId, seatGradeId, remaining);
+        Long result = redisTemplate.execute(
+                DECREMENT_IF_POSITIVE,
+                List.of(key),
+                seatGradeId.toString()
+        );
+        if (result == null || result < 0) {
+            log.warn("[SeatAvailability] decrement 실패 — Redis 키 없음. "
+                    + "APPROVED 전 이벤트 수신 또는 키 만료. matchId={}, seatGradeId={}", matchId, seatGradeId);
+        } else if (result == 0) {
+            log.warn("[SeatAvailability] decrement 무시 — 잔여 좌석 이미 0. "
+                    + "중복 이벤트 또는 초과 예매 시도. matchId={}, seatGradeId={}", matchId, seatGradeId);
+        } else {
+            log.debug("[SeatAvailability] decrement matchId={}, seatGradeId={}, remaining={}", matchId, seatGradeId, result);
+        }
     }
 
     @Override

--- a/src/main/java/org/ticketing/match/infrastructure/redis/RedisSeatAvailabilityRepository.java
+++ b/src/main/java/org/ticketing/match/infrastructure/redis/RedisSeatAvailabilityRepository.java
@@ -1,0 +1,76 @@
+package org.ticketing.match.infrastructure.redis;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+import org.ticketing.match.domain.repository.SeatAvailabilityRepository;
+
+/**
+ * Redis Hash 기반 SeatAvailabilityRepository 구현체.
+ *
+ * <p>Hash 키 구조: {@code seat:remaining:{matchId}}
+ * <p>field: seatGradeId(UUID 문자열), value: 잔여 좌석 수(Long 문자열)
+ *
+ * <p>{@code HINCRBY} 를 사용하므로 decrement / increment 가 원자적으로 처리된다.
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class RedisSeatAvailabilityRepository implements SeatAvailabilityRepository {
+
+    private static final String KEY_PREFIX = "seat:remaining:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public void initialize(UUID matchId, Map<UUID, Long> seatCountByGrade) {
+        String key = buildKey(matchId);
+        Map<String, String> hash = new HashMap<>();
+        seatCountByGrade.forEach((gradeId, count) -> hash.put(gradeId.toString(), count.toString()));
+        redisTemplate.opsForHash().putAll(key, hash);
+        log.info("[SeatAvailability] initialized matchId={}, grades={}", matchId, seatCountByGrade.size());
+    }
+
+    @Override
+    public void decrement(UUID matchId, UUID seatGradeId) {
+        String key = buildKey(matchId);
+        Long remaining = redisTemplate.opsForHash().increment(key, seatGradeId.toString(), -1L);
+        log.debug("[SeatAvailability] decrement matchId={}, seatGradeId={}, remaining={}", matchId, seatGradeId, remaining);
+    }
+
+    @Override
+    public void increment(UUID matchId, UUID seatGradeId) {
+        String key = buildKey(matchId);
+        Long remaining = redisTemplate.opsForHash().increment(key, seatGradeId.toString(), 1L);
+        log.debug("[SeatAvailability] increment matchId={}, seatGradeId={}, remaining={}", matchId, seatGradeId, remaining);
+    }
+
+    @Override
+    public Map<UUID, Long> findAll(UUID matchId) {
+        String key = buildKey(matchId);
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries(key);
+        if (entries == null || entries.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<UUID, Long> result = new HashMap<>();
+        entries.forEach((field, value) -> {
+            try {
+                UUID gradeId = UUID.fromString(field.toString());
+                long count = Long.parseLong(value.toString());
+                result.put(gradeId, count);
+            } catch (Exception e) {
+                log.warn("[SeatAvailability] invalid entry key={}, field={}", key, field);
+            }
+        });
+        return result;
+    }
+
+    private String buildKey(UUID matchId) {
+        return KEY_PREFIX + matchId;
+    }
+}

--- a/src/main/java/org/ticketing/match/presentation/controller/MatchController.java
+++ b/src/main/java/org/ticketing/match/presentation/controller/MatchController.java
@@ -26,6 +26,7 @@ import org.ticketing.match.presentation.dto.request.UpdateMatchRequestDto;
 import org.ticketing.match.presentation.dto.request.UpdateMatchZonePolicyRequestDto;
 import org.ticketing.match.presentation.dto.response.MatchResponseDto;
 import org.ticketing.match.presentation.dto.response.MatchZonePolicyResponseDto;
+import org.ticketing.match.presentation.dto.response.RemainingSeatsResponseDto;
 
 @RestController
 @RequestMapping("/api/matches")
@@ -51,6 +52,13 @@ public class MatchController {
     public MatchResponseDto getMatch(@PathVariable UUID matchId) {
         return MatchResponseDto.from(
                 matchApplicationService.findMatch(new FindMatchQuery(matchId))
+        );
+    }
+
+    @GetMapping("/{matchId}/remaining-seats")
+    public RemainingSeatsResponseDto getRemainingSeats(@PathVariable UUID matchId) {
+        return RemainingSeatsResponseDto.from(
+                matchApplicationService.getRemainingSeats(matchId)
         );
     }
 

--- a/src/main/java/org/ticketing/match/presentation/dto/response/RemainingSeatsResponseDto.java
+++ b/src/main/java/org/ticketing/match/presentation/dto/response/RemainingSeatsResponseDto.java
@@ -1,0 +1,36 @@
+package org.ticketing.match.presentation.dto.response;
+
+import java.util.List;
+import java.util.UUID;
+import org.ticketing.match.application.dto.result.RemainingSeatsResult;
+import org.ticketing.match.application.dto.result.RemainingSeatsResult.ZoneAvailability;
+
+public record RemainingSeatsResponseDto(
+        UUID matchId,
+        List<ZoneDto> zones
+) {
+
+    public record ZoneDto(
+            UUID seatGradeId,
+            Long price,
+            Long totalSeatCount,
+            Long remainingCount
+    ) {
+
+        public static ZoneDto from(ZoneAvailability zone) {
+            return new ZoneDto(
+                    zone.seatGradeId(),
+                    zone.price(),
+                    zone.totalSeatCount(),
+                    zone.remainingCount()
+            );
+        }
+    }
+
+    public static RemainingSeatsResponseDto from(RemainingSeatsResult result) {
+        List<ZoneDto> zones = result.zones().stream()
+                .map(ZoneDto::from)
+                .toList();
+        return new RemainingSeatsResponseDto(result.matchId(), zones);
+    }
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -25,6 +25,11 @@ spring:
   flyway:
     enabled: false
 
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     producer:
@@ -40,3 +45,12 @@ eureka:
   client:
     register-with-eureka: true
     fetch-registry: true
+
+topics:
+  match:
+    approved: match.approved
+    canceled: match.canceled
+  reservation:
+    seat:
+      reserved: reservation.seat.reserved
+      released: reservation.seat.released

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,13 @@ spring:
         jwt:
           issuer-uri: http://localhost:18080/realms/ticketing
 
+  kafka:
+    consumer:
+      # auto-commit 비활성화 — AckMode.RECORD 로 처리 완료 후 수동 커밋
+      enable-auto-commit: false
+      # 좌석 이벤트는 처리량이 크지 않으므로 50으로 제한
+      max-poll-records: 50
+
 management:
   metrics:
     tags:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,3 +19,12 @@ management:
     web:
       exposure:
         include: health,info,prometheus
+
+topics:
+  match:
+    approved: match.approved
+    canceled: match.canceled
+  reservation:
+    seat:
+      reserved: reservation.seat.reserved
+      released: reservation.seat.released


### PR DESCRIPTION
###📎 관련 이슈

close #14 

###📌 작업 내용
Redis Hash 기반으로 경기 구역별 실시간 잔여 좌석 수를 관리하고 조회하는 기능을 구현했습니다. 경기 APPROVED 시 Redis를 초기화하고, reservation-service에서 발행하는 예매/취소 Kafka 이벤트를 소비하여 카운터를 갱신합니다. 조회 API는 Redis와 DB를 조인하여 구역별 가격·총 좌석 수·잔여 좌석 수를 반환합니다.

###✨ 변경 사항

SeatGradeClient — countBySeatGradeId 추가 (CommonResponse<Long> 반환)
SeatGradeProvider / SeatGradeProviderImpl — countBySeatGradeId 구현
MatchZonePolicy — totalSeatCount 필드 추가, ZonePolicy 생성 시 seat-service에서 조회하여 저장
SeatAvailabilityRepository — 도메인 인터페이스 신규 작성 (initialize / decrement / increment / findAll)
RedisSeatAvailabilityRepository — Redis Hash 기반 구현체 (HINCRBY로 원자적 증감)
MatchWriteService.changeStatus() — APPROVED 전환 시 afterCommit() 콜백으로 Redis 초기화
ReservationSeatEventConsumer — reservation.seat.reserved → decrement, reservation.seat.released → increment
KafkaTopicConfig — reservation.seat.reserved / released 토픽 빈 추가
MatchApplicationService.getRemainingSeats() — Redis + ZonePolicy 조인 후 결과 반환
MatchController — GET /api/matches/{matchId}/remaining-seats 엔드포인트 추가
application.yaml / config repo — Redis 연결, Kafka producer/consumer 직렬화, 토픽명 설정 추가

###📝 리뷰 포인트 (선택)

MatchWriteService.changeStatus()에서 Redis 초기화를 TransactionSynchronization.afterCommit() 안에서 실행합니다. DB 커밋 성공 이후에만 Redis가 갱신되므로 롤백 시 Redis 오염이 없지만, Redis 초기화 자체가 실패해도 트랜잭션은 이미 커밋된 상태입니다. 이 trade-off가 적절한지 확인 부탁드립니다.
RedisSeatAvailabilityRepository.findAll()에서 Redis 캐시가 없는 구역은 totalSeatCount로 fallback 처리합니다. APPROVED 이전에 조회 요청이 오는 경우를 방어하기 위한 처리인데, 빈 맵 반환 또는 예외 처리가 더 적절한지 의견 부탁드립니다.

###🧠 기타 참고 사항

SeatGradeClient.countBySeatGradeId는 seat-service의 GET /internal/seat-grades/{seatGradeId}/count 엔드포인트를 호출합니다. seat-service 측에 해당 엔드포인트가 구현되어 있어야 정상 동작합니다.
Kafka 토픽 reservation.seat.reserved / reservation.seat.released는 reservation-service에서 발행합니다. 해당 이벤트 페이로드에 seatGradeId 필드가 포함되어 있어야 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoint to query real-time remaining seat counts per zone for a match, including seat grade details (price, total seats, remaining seats).
  * Implemented real-time seat availability tracking that automatically updates when reservations are made or canceled.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3s-ticketing/match-service/pull/15)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->