### PR TITLE
[FEAT] match reservation internal 통신

### DIFF
--- a/src/main/java/org/ticketing/match/application/service/MatchApplicationService.java
+++ b/src/main/java/org/ticketing/match/application/service/MatchApplicationService.java
@@ -29,6 +29,8 @@ import org.ticketing.match.domain.repository.SeatAvailabilityRepository;
 import org.ticketing.match.domain.service.ClubProvider;
 import org.ticketing.match.domain.service.SeatGradeProvider;
 import org.ticketing.match.domain.service.StadiumProvider;
+import org.ticketing.match.domain.exception.MatchZonePolicyNotFoundException;
+
 
 /**
  * Match 어그리게이트 오케스트레이션 서비스.

--- a/src/main/java/org/ticketing/match/application/service/MatchApplicationService.java
+++ b/src/main/java/org/ticketing/match/application/service/MatchApplicationService.java
@@ -185,4 +185,36 @@ public class MatchApplicationService {
     public void removeZonePolicy(RemoveMatchZonePolicyCommand command) {
         matchWriteService.removeZonePolicy(command);
     }
+
+    // ──────────────────────────────────────────
+    // 내부 서비스 간 통신 — reservation-service 가격 조회
+    // ──────────────────────────────────────────
+
+    /**
+     * 경기-좌석등급 조합의 가격 정책 조회.
+     *
+     * <p>reservation-service 가 좌석 confirm(결제 확정) 시 가격을 스냅샷으로 저장해야 하므로
+     * 내부 API 로 조회한다. {@code /internal/matches/{matchId}/seat-grades/{seatGradeId}}
+     *
+     * @param matchId      경기 ID
+     * @param seatGradeId  좌석 등급 ID
+     * @return 해당 경기의 좌석 등급별 가격 ({@link SeatGradePrice})
+     * @throws MatchNotFoundException            경기가 존재하지 않을 때
+     * @throws MatchZonePolicyNotFoundException  해당 등급의 ZonePolicy 가 없을 때
+     */
+    @Transactional(readOnly = true)
+    public SeatGradePrice getSeatGradePrice(UUID matchId, UUID seatGradeId) {
+        Match match = matchRepository.findActiveById(matchId)
+                .orElseThrow(() -> new MatchNotFoundException(matchId));
+
+        MatchZonePolicy policy = match.getZonePolicies().stream()
+                .filter(p -> p.getSeatGradeId().equals(seatGradeId) && p.getDeletedAt() == null)
+                .findFirst()
+                .orElseThrow(() -> new MatchZonePolicyNotFoundException(seatGradeId));
+
+        return new SeatGradePrice(policy.getSeatGradeId(), policy.getPrice());
+    }
+
+    /** 내부 조회 결과 — 좌석 등급 ID + 가격. */
+    public record SeatGradePrice(UUID seatGradeId, Long price) {}
 }

--- a/src/main/java/org/ticketing/match/presentation/controller/InternalMatchController.java
+++ b/src/main/java/org/ticketing/match/presentation/controller/InternalMatchController.java
@@ -1,0 +1,50 @@
+package org.ticketing.match.presentation.controller;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.ticketing.match.application.service.MatchApplicationService;
+import org.ticketing.match.presentation.dto.response.internal.SeatGradePriceResponseDto;
+
+/**
+ * 서비스 간 내부 통신 전용 컨트롤러.
+ *
+ * <h3>접근 제어</h3>
+ * <p>{@code /internal/**} 경로는 API Gateway 에서 외부 노출이 차단된다.
+ * 서비스 내부 네트워크에서만 호출 가능하며, 별도 JWT 검증 없이 동작한다
+ * (게이트웨이가 외부 요청을 이미 필터링하므로).
+ *
+ * <h3>응답 형식</h3>
+ * <p>공통 모듈의 {@code GlobalResponseAdvice} 가 자동으로
+ * {@code {success, message, data, traceId}} 형태로 래핑한다.
+ * 호출 측(reservation-service)의 Feign DTO 는 이 래퍼 구조를 포함해야 한다.
+ */
+@RestController
+@RequestMapping("/internal/matches")
+@RequiredArgsConstructor
+public class InternalMatchController {
+
+    private final MatchApplicationService matchApplicationService;
+
+    /**
+     * 경기-좌석등급 조합의 가격 조회.
+     *
+     * <p>reservation-service 가 좌석 confirm 시 가격 스냅샷을 저장하기 위해 호출한다.
+     *
+     * @param matchId     경기 ID
+     * @param seatGradeId 좌석 등급 ID
+     * @return 해당 경기의 좌석 등급 가격 정보
+     */
+    @GetMapping("/{matchId}/seat-grades/{seatGradeId}")
+    public SeatGradePriceResponseDto getSeatGradePrice(
+            @PathVariable UUID matchId,
+            @PathVariable UUID seatGradeId
+    ) {
+        MatchApplicationService.SeatGradePrice result =
+                matchApplicationService.getSeatGradePrice(matchId, seatGradeId);
+        return SeatGradePriceResponseDto.of(result.seatGradeId(), result.price());
+    }
+}

--- a/src/main/java/org/ticketing/match/presentation/dto/response/internal/SeatGradePriceResponseDto.java
+++ b/src/main/java/org/ticketing/match/presentation/dto/response/internal/SeatGradePriceResponseDto.java
@@ -1,0 +1,18 @@
+package org.ticketing.match.presentation.dto.response.internal;
+
+import java.util.UUID;
+
+/**
+ * 내부 서비스 간 통신용 좌석 등급 가격 응답 DTO.
+ *
+ * <p>reservation-service 가 좌석 hold/confirm 시 가격 메타데이터를 조회하기 위해 사용한다.
+ * 공통 모듈의 {@code @RestControllerAdvice} 가 {@code {success, data, traceId}} 형태로 래핑한다.
+ */
+public record SeatGradePriceResponseDto(
+        UUID seatGradeId,
+        Long price
+) {
+    public static SeatGradePriceResponseDto of(UUID seatGradeId, Long price) {
+        return new SeatGradePriceResponseDto(seatGradeId, price);
+    }
+}


### PR DESCRIPTION
📎 관련 이슈

close #16 

📌 작업 내용

MatchApplicationService에 getSeatGradePrice(matchId, seatGradeId) 메서드 추가

MatchRepository로 경기 조회 후, getZonePolicies() 스트림에서 seatGradeId가 일치하고 삭제되지 않은 정책 탐색
정책이 없으면 MatchZonePolicyNotFoundException 발생
결과를 내부 record SeatGradePrice(seatGradeId, price)로 반환


InternalMatchController 신규 생성 (/internal/matches)

GET /{matchId}/seat-grades/{seatGradeId} 엔드포인트 추가
서비스 결과를 SeatGradePriceResponseDto로 변환하여 반환


SeatGradePriceResponseDto 신규 생성 (presentation/dto/response/internal)

내부 통신 전용 응답 record: seatGradeId, price



✨ 변경 사항

[추가] MatchApplicationService — getSeatGradePrice() 서비스 메서드 및 SeatGradePrice result record
[추가] InternalMatchController — GET /internal/matches/{matchId}/seat-grades/{seatGradeId}
[추가] SeatGradePriceResponseDto — 내부 API 응답 DTO

📝 리뷰 포인트 (선택)

match.getZonePolicies() 스트림 조회 시 @Transactional(readOnly = true) 세션 유지가 필요함 — LazyInitializationException 방지를 위해 서비스 메서드에 어노테이션 선언
/internal/** 경로는 현재 MatchSecurityConfig의 anyRequest().permitAll() 정책으로 인증 없이 접근 가능. 추후 WebSecurityConfig 활성화 시 permitAll() 목록에 /internal/**가 명시되어 있어 별도 수정 불필요
동일 matchId에 seatGradeId가 중복 등록된 케이스는 addZonePolicy 단계에서 DuplicateMatchZonePolicyException으로 방지되므로, findFirst()로 안전하게 단일 정책 반환 가능

🧠 기타 참고 사항

공통 모듈의 GlobalResponseAdvice가 응답을 { success, message, data, traceId } 형태로 래핑하므로, reservation-service의 SeatGradePriceResponse Feign DTO도 동일한 래퍼 구조로 업데이트 필요 (PR 연동)
내부 API 설계 참고: PaymentStatusResponse (reservation-service) — 동일한 래퍼 패턴 적용 사례

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internal API endpoint to retrieve seat grade pricing information for a specified match and seat grade.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3s-ticketing/match-service/pull/17)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->