### PR TITLE
feat: add CI/CD workflow for match-service

### DIFF
--- a/.github/workflows/match-service-ci.yml
+++ b/.github/workflows/match-service-ci.yml
@@ -1,0 +1,44 @@
+name: Match Service CI
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+  push:
+    branches:
+      - dev
+      - main
+      - feature/**
+      - feat/**
+      - fix/**
+      - chore/**
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build-and-test:
+    name: Build and Test match-service
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Grant execute permission for Gradle wrapper
+        run: chmod +x ./gradlew
+
+      - name: Run tests
+        env:
+          GPR_USER: ${{ secrets.GPR_USER }}
+          GPR_TOKEN: ${{ secrets.GPR_TOKEN }}
+        run: ./gradlew clean test

--- a/.github/workflows/match-service-deploy.yml
+++ b/.github/workflows/match-service-deploy.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./gradlew clean test
 
       - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.GPR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GPR_USER }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/match-service-deploy.yml
+++ b/.github/workflows/match-service-deploy.yml
@@ -1,0 +1,71 @@
+name: Match Service CD
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: 3s-ticketing/match-service
+  IMAGE_TAG: main-latest
+
+jobs:
+  build-and-push:
+    name: Build and Push match-service image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Grant execute permission for Gradle wrapper
+        run: chmod +x ./gradlew
+
+      - name: Run tests
+        env:
+          GPR_USER: ${{ secrets.GPR_USER }}
+          GPR_TOKEN: ${{ secrets.GPR_TOKEN }}
+        run: ./gradlew clean test
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GPR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GPR_USER }} --password-stdin
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            --build-arg GPR_USER=${{ secrets.GPR_USER }} \
+            --build-arg GPR_TOKEN=${{ secrets.GPR_TOKEN }} \
+            -t $REGISTRY/$IMAGE_NAME:$IMAGE_TAG \
+            -t $REGISTRY/$IMAGE_NAME:${{ github.sha }} \
+            .
+
+      - name: Push Docker image
+        run: |
+          docker push $REGISTRY/$IMAGE_NAME:$IMAGE_TAG
+          docker push $REGISTRY/$IMAGE_NAME:${{ github.sha }}
+
+      - name: Deploy match-service to EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            echo "${{ secrets.GPR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.GPR_USER }} --password-stdin
+            cd ~/deploy/ticketing/ticketing-system
+            docker compose -f docker-compose.app.yml pull match-service
+            docker compose -f docker-compose.app.yml up -d --no-deps --force-recreate match-service
+            docker ps --filter "name=ticketing-match-service"
+            docker image prune -f


### PR DESCRIPTION
### 📎 관련 이슈
- close #19

### 📌 작업 내용
- match-service에 GitHub Actions 기반 CI/CD workflow를 도입했습니다.
- PR/push 시 Gradle test를 수행하는 CI workflow를 추가했습니다.
- main 브랜치 병합 시 Docker 이미지를 build/push하고, GHCR에 `main-latest` 태그로 배포하도록 CD workflow를 추가했습니다.
- GHCR 이미지 push 이후 EC2에 SSH로 접속하여 match-service 컨테이너만 자동 재배포하도록 구성했습니다.

### ✨ 변경 사항
- `.github/workflows/match-service-ci.yml` 추가
- `.github/workflows/match-service-deploy.yml` 추가
- GHCR 이미지 build/push 설정 추가
  - `ghcr.io/3s-ticketing/match-service:main-latest`
  - `ghcr.io/3s-ticketing/match-service:{commit-sha}`
- EC2 배포 단계 추가
  - `docker compose -f docker-compose.app.yml pull match-service`
  - `docker compose -f docker-compose.app.yml up -d --no-deps --force-recreate match-service`
- 배포 시 EC2 내부에서 GHCR 인증을 수행하도록 `docker login ghcr.io` 단계 추가
- 배포 후 `ticketing-match-service` 컨테이너 상태 확인 명령 추가

### 📝 리뷰 포인트 (선택)
- workflow 내 서비스명, 이미지명, 컨테이너명이 match-service 기준으로 올바르게 설정되었는지 확인 부탁드립니다.
  - image: `ghcr.io/3s-ticketing/match-service:main-latest`
  - compose service: `match-service`
  - container: `ticketing-match-service`
- 전체 서비스를 재기동하지 않고 match-service만 재배포하도록 `--no-deps --force-recreate match-service` 옵션을 사용했습니다.
- GitHub Secrets 설정이 정상 적용되는지 확인이 필요합니다.
  - `GPR_USER`
  - `GPR_TOKEN`
  - `EC2_HOST`
  - `EC2_USER`
  - `EC2_SSH_KEY`

### 🧠 기타 참고 사항
- user-service에서 동일한 방식의 CI/CD 자동 배포 흐름을 먼저 검증했습니다.
- club-service에도 동일한 방식의 CI/CD workflow를 적용 중입니다.
- `ticketing-system/docker-compose.app.yml`에서 match-service가 `image: ghcr.io/3s-ticketing/match-service:main-latest`를 바라보도록 변경되어 있어야 `docker compose pull match-service`가 정상 동작합니다.
- main 병합 후 Actions 탭에서 CD workflow 성공 여부와 EC2 컨테이너 재기동 여부를 확인할 예정입니다.