### PR TITLE
[FEAT] match-service: L1 Caffeine 캐시 도입으로 MatchSnapshot·잔여좌석 성능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,10 @@ dependencies {
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.apache.commons:commons-pool2'  // Lettuce 커넥션 풀 활성화
+
+	// Caffeine — L1 로컬 캐시 (Redis 장애 시 fallback, Stampede 완전 차단)
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'com.github.ben-manes.caffeine:caffeine'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/ticketing/match/application/dto/result/MatchSnapshot.java
+++ b/src/main/java/org/ticketing/match/application/dto/result/MatchSnapshot.java
@@ -1,0 +1,37 @@
+package org.ticketing.match.application.dto.result;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.UUID;
+import org.ticketing.match.domain.model.Match;
+
+/**
+ * Redis 캐시에 저장되는 Match + ZonePolicy 스냅샷.
+ *
+ * <p>JPA 엔티티를 캐싱하면 Hibernate 프록시·LazyInitialization 문제가 생기므로,
+ * 순수 데이터 record 로 변환해 캐싱한다.
+ * ZonePolicy 는 삭제된 것을 제외한 활성 목록만 포함한다.
+ */
+public record MatchSnapshot(
+        UUID matchId,
+        List<ZonePolicySnapshot> zonePolicies
+) implements Serializable {
+
+    public record ZonePolicySnapshot(
+            UUID seatGradeId,
+            Long price,
+            Long totalSeatCount
+    ) implements Serializable {}
+
+    public static MatchSnapshot from(Match match) {
+        List<ZonePolicySnapshot> policies = match.getZonePolicies().stream()
+                .filter(p -> p.getDeletedAt() == null)
+                .map(p -> new ZonePolicySnapshot(
+                        p.getSeatGradeId(),
+                        p.getPrice(),
+                        p.getTotalSeatCount()
+                ))
+                .toList();
+        return new MatchSnapshot(match.getId(), policies);
+    }
+}

--- a/src/main/java/org/ticketing/match/application/service/MatchApplicationService.java
+++ b/src/main/java/org/ticketing/match/application/service/MatchApplicationService.java
@@ -24,7 +24,6 @@ import org.ticketing.match.domain.exception.SeatGradeNotFoundException;
 import org.ticketing.match.domain.exception.StadiumNotFoundException;
 import org.ticketing.match.domain.model.Match;
 import org.ticketing.match.domain.repository.MatchRepository;
-import org.ticketing.match.domain.repository.SeatAvailabilityRepository;
 import org.ticketing.match.domain.service.ClubProvider;
 import org.ticketing.match.domain.service.SeatGradeProvider;
 import org.ticketing.match.domain.service.StadiumProvider;
@@ -60,10 +59,10 @@ public class MatchApplicationService {
     private final MatchRepository matchRepository;
     private final MatchWriteService matchWriteService;
     private final MatchSnapshotCacheService matchSnapshotCacheService;
+    private final SeatAvailabilityCacheService seatAvailabilityCacheService;
     private final ClubProvider clubProvider;
     private final StadiumProvider stadiumProvider;
     private final SeatGradeProvider seatGradeProvider;
-    private final SeatAvailabilityRepository seatAvailabilityRepository;
 
     // ──────────────────────────────────────────
     // Match 생성 — Feign 검증 후 커맨드 서비스에 위임
@@ -116,16 +115,23 @@ public class MatchApplicationService {
     }
 
     /**
-     * 경기의 구역별 실시간 잔여 좌석 수 조회.
+     * 경기의 구역별 잔여 좌석 수 조회 (표시용).
      *
-     * <p>Match + ZonePolicy 정적 데이터는 {@link MatchSnapshotCacheService} 를 통해 Redis 에서 읽는다.
-     * 캐시 히트 시 DB 쿼리 0회 / 캐시 미스 시 fetch join 으로 단 1번만 DB 조회.
-     * 실시간 잔여 좌석 수는 {@link SeatAvailabilityRepository} (Redis Hash) 에서 읽는다.
+     * <p>두 캐시를 조합하여 응답을 구성한다:
+     * <ol>
+     *   <li>{@link MatchSnapshotCacheService}: Match + ZonePolicy 정적 구조
+     *       — L1(Caffeine 5분) → L2(Redis 60분) → DB(fetch join)</li>
+     *   <li>{@link SeatAvailabilityCacheService}: 구역별 잔여 좌석 수
+     *       — L1(Caffeine 2초) → Redis {@code HGETALL} (2초당 최대 1회)</li>
+     * </ol>
+     *
+     * <p>실제 예약 가능 여부 판단 및 좌석 차감은 reservation-service 의 Redis DECR 로
+     * 별도 처리되므로, 이 메서드의 2초 오차는 표시용에 한해 허용된다.
      */
     public RemainingSeatsResult getRemainingSeats(UUID matchId) {
         MatchSnapshot snapshot = matchSnapshotCacheService.getSnapshot(matchId);
 
-        Map<UUID, Long> remaining = seatAvailabilityRepository.findAll(matchId);
+        Map<UUID, Long> remaining = seatAvailabilityCacheService.getRemaining(matchId);
 
         List<ZoneAvailability> zones = snapshot.zonePolicies().stream()
                 .map(p -> new ZoneAvailability(

--- a/src/main/java/org/ticketing/match/application/service/MatchApplicationService.java
+++ b/src/main/java/org/ticketing/match/application/service/MatchApplicationService.java
@@ -23,12 +23,12 @@ import org.ticketing.match.domain.exception.MatchNotFoundException;
 import org.ticketing.match.domain.exception.SeatGradeNotFoundException;
 import org.ticketing.match.domain.exception.StadiumNotFoundException;
 import org.ticketing.match.domain.model.Match;
-import org.ticketing.match.domain.model.MatchZonePolicy;
 import org.ticketing.match.domain.repository.MatchRepository;
 import org.ticketing.match.domain.repository.SeatAvailabilityRepository;
 import org.ticketing.match.domain.service.ClubProvider;
 import org.ticketing.match.domain.service.SeatGradeProvider;
 import org.ticketing.match.domain.service.StadiumProvider;
+import org.ticketing.match.application.dto.result.MatchSnapshot;
 import org.ticketing.match.domain.exception.MatchZonePolicyNotFoundException;
 
 
@@ -59,6 +59,7 @@ public class MatchApplicationService {
 
     private final MatchRepository matchRepository;
     private final MatchWriteService matchWriteService;
+    private final MatchSnapshotCacheService matchSnapshotCacheService;
     private final ClubProvider clubProvider;
     private final StadiumProvider stadiumProvider;
     private final SeatGradeProvider seatGradeProvider;
@@ -117,27 +118,21 @@ public class MatchApplicationService {
     /**
      * 경기의 구역별 실시간 잔여 좌석 수 조회.
      *
-     * <p>Redis Hash 에서 잔여 좌석 수를 읽고, DB 의 ZonePolicy(가격·총 좌석 수) 와 조인하여 반환한다.
-     * Redis 캐시가 없는 구역은 totalSeatCount 를 remainingCount 로 대체한다
-     * (APPROVED 전 조회 등 초기화 전 상태 방어).
-     *
-     * <p>{@code @Transactional(readOnly = true)} 를 선언하여 {@code match.getZonePolicies()} 지연 로딩 시
-     * Hibernate 세션이 열려 있도록 보장한다. 없으면 {@link org.hibernate.LazyInitializationException} 발생.
+     * <p>Match + ZonePolicy 정적 데이터는 {@link MatchSnapshotCacheService} 를 통해 Redis 에서 읽는다.
+     * 캐시 히트 시 DB 쿼리 0회 / 캐시 미스 시 fetch join 으로 단 1번만 DB 조회.
+     * 실시간 잔여 좌석 수는 {@link SeatAvailabilityRepository} (Redis Hash) 에서 읽는다.
      */
-    @Transactional(readOnly = true)
     public RemainingSeatsResult getRemainingSeats(UUID matchId) {
-        Match match = matchRepository.findActiveById(matchId)
-                .orElseThrow(() -> new MatchNotFoundException(matchId));
+        MatchSnapshot snapshot = matchSnapshotCacheService.getSnapshot(matchId);
 
         Map<UUID, Long> remaining = seatAvailabilityRepository.findAll(matchId);
 
-        List<ZoneAvailability> zones = match.getZonePolicies().stream()
-                .filter(p -> p.getDeletedAt() == null)
+        List<ZoneAvailability> zones = snapshot.zonePolicies().stream()
                 .map(p -> new ZoneAvailability(
-                        p.getSeatGradeId(),
-                        p.getPrice(),
-                        p.getTotalSeatCount(),
-                        remaining.getOrDefault(p.getSeatGradeId(), p.getTotalSeatCount())
+                        p.seatGradeId(),
+                        p.price(),
+                        p.totalSeatCount(),
+                        remaining.getOrDefault(p.seatGradeId(), p.totalSeatCount())
                 ))
                 .toList();
 
@@ -204,17 +199,14 @@ public class MatchApplicationService {
      * @throws MatchNotFoundException            경기가 존재하지 않을 때
      * @throws MatchZonePolicyNotFoundException  해당 등급의 ZonePolicy 가 없을 때
      */
-    @Transactional(readOnly = true)
     public SeatGradePrice getSeatGradePrice(UUID matchId, UUID seatGradeId) {
-        Match match = matchRepository.findActiveById(matchId)
-                .orElseThrow(() -> new MatchNotFoundException(matchId));
+        MatchSnapshot snapshot = matchSnapshotCacheService.getSnapshot(matchId);
 
-        MatchZonePolicy policy = match.getZonePolicies().stream()
-                .filter(p -> p.getSeatGradeId().equals(seatGradeId) && p.getDeletedAt() == null)
+        return snapshot.zonePolicies().stream()
+                .filter(p -> p.seatGradeId().equals(seatGradeId))
                 .findFirst()
+                .map(p -> new SeatGradePrice(p.seatGradeId(), p.price()))
                 .orElseThrow(() -> new MatchZonePolicyNotFoundException(seatGradeId));
-
-        return new SeatGradePrice(policy.getSeatGradeId(), policy.getPrice());
     }
 
     /** 내부 조회 결과 — 좌석 등급 ID + 가격. */

--- a/src/main/java/org/ticketing/match/application/service/MatchSnapshotCacheService.java
+++ b/src/main/java/org/ticketing/match/application/service/MatchSnapshotCacheService.java
@@ -1,0 +1,60 @@
+package org.ticketing.match.application.service;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.ticketing.match.application.dto.result.MatchSnapshot;
+import org.ticketing.match.domain.exception.MatchNotFoundException;
+import org.ticketing.match.domain.model.Match;
+import org.ticketing.match.domain.repository.MatchRepository;
+
+import static org.ticketing.match.infrastructure.config.MatchCacheConfig.MATCH_SNAPSHOT_CACHE;
+
+/**
+ * Match + ZonePolicy 데이터를 Redis 에 캐싱하는 서비스.
+ *
+ * <h3>캐시 전략</h3>
+ * <ul>
+ *   <li>캐시 히트 : Redis 에서 {@link MatchSnapshot} 을 즉시 반환 (DB 쿼리 0회)</li>
+ *   <li>캐시 미스 : fetch join 으로 Match + ZonePolicies 를 단 1번 DB 조회 후 Redis 에 저장</li>
+ *   <li>쓰기(update/delete/addZonePolicy 등) 후 {@link #evict} 호출로 캐시 무효화</li>
+ * </ul>
+ *
+ * <h3>주의</h3>
+ * <p>캐시 어드바이스({@code @Cacheable})는 Spring AOP 프록시를 통해서만 동작한다.
+ * 같은 클래스 내 자기 호출(self-invocation)에는 적용되지 않는다.
+ */
+@Service
+@RequiredArgsConstructor
+public class MatchSnapshotCacheService {
+
+    private final MatchRepository matchRepository;
+
+    /**
+     * Match 스냅샷 조회 (캐시 우선).
+     *
+     * <p>{@code @Transactional(readOnly = true)} 는 캐시 미스 시 DB 조회에만 필요하다.
+     * 캐시 히트 시에는 트랜잭션이 열리지 않아 DB 커넥션을 소비하지 않는다.
+     */
+    @Cacheable(value = MATCH_SNAPSHOT_CACHE, key = "#matchId")
+    @Transactional(readOnly = true)
+    public MatchSnapshot getSnapshot(UUID matchId) {
+        Match match = matchRepository.findActiveByIdWithPolicies(matchId)
+                .orElseThrow(() -> new MatchNotFoundException(matchId));
+        return MatchSnapshot.from(match);
+    }
+
+    /**
+     * 캐시 무효화.
+     *
+     * <p>Match 또는 ZonePolicy 가 변경된 후 호출한다.
+     * 다음 {@link #getSnapshot} 호출 시 DB 에서 최신 데이터를 다시 로드한다.
+     */
+    @CacheEvict(value = MATCH_SNAPSHOT_CACHE, key = "#matchId")
+    public void evict(UUID matchId) {
+        // 어노테이션이 캐시 항목을 삭제한다. 메서드 본문은 비워도 된다.
+    }
+}

--- a/src/main/java/org/ticketing/match/application/service/MatchSnapshotCacheService.java
+++ b/src/main/java/org/ticketing/match/application/service/MatchSnapshotCacheService.java
@@ -1,8 +1,10 @@
 package org.ticketing.match.application.service;
 
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.CacheEvict;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,32 +16,59 @@ import org.ticketing.match.domain.repository.MatchRepository;
 import static org.ticketing.match.infrastructure.config.MatchCacheConfig.MATCH_SNAPSHOT_CACHE;
 
 /**
- * Match + ZonePolicy 데이터를 Redis 에 캐싱하는 서비스.
+ * Match + ZonePolicy 데이터를 L1(Caffeine) → L2(Redis) 2계층으로 캐싱하는 서비스.
  *
  * <h3>캐시 전략</h3>
  * <ul>
- *   <li>캐시 히트 : Redis 에서 {@link MatchSnapshot} 을 즉시 반환 (DB 쿼리 0회)</li>
- *   <li>캐시 미스 : fetch join 으로 Match + ZonePolicies 를 단 1번 DB 조회 후 Redis 에 저장</li>
- *   <li>쓰기(update/delete/addZonePolicy 등) 후 {@link #evict} 호출로 캐시 무효화</li>
+ *   <li>캐시 히트(L1) : Caffeine JVM 로컬 캐시에서 즉시 반환 (~0ms, DB·Redis 쿼리 0회)</li>
+ *   <li>캐시 히트(L2) : Redis 에서 {@link MatchSnapshot} 반환 (~1ms, DB 쿼리 0회)</li>
+ *   <li>캐시 미스 : fetch join 으로 Match + ZonePolicies 를 단 1번 DB 조회 후 L1·L2 모두 저장</li>
+ *   <li>쓰기(update/delete/addZonePolicy 등) 후 {@link #evict} 호출로 L1·L2 모두 무효화</li>
  * </ul>
  *
- * <h3>주의</h3>
- * <p>캐시 어드바이스({@code @Cacheable})는 Spring AOP 프록시를 통해서만 동작한다.
- * 같은 클래스 내 자기 호출(self-invocation)에는 적용되지 않는다.
+ * <h3>Cache Stampede 방지</h3>
+ * <p>{@code sync = true}: 캐시 미스 시 단 하나의 스레드만 DB 를 조회하고 나머지는 결과를 기다린다.
+ * Caffeine 은 {@code computeIfAbsent} 로 JVM 내 단일 로더를 보장한다.
+ *
+ * <h3>Self-invocation 주의</h3>
+ * <p>{@code @Cacheable} 은 Spring AOP 프록시를 통해서만 동작한다.
+ * 같은 빈 내에서 {@code this.getSnapshot()} 을 호출하면 프록시를 우회하여 캐시가 적용되지 않는다.
+ * Warm-up 은 반드시 외부 빈({@link org.ticketing.match.application.service.MatchWriteService})에서
+ * 이 서비스의 프록시 메서드({@link #getSnapshot})를 직접 호출해야 한다.
+ *
+ * <h3>Evict 양쪽 계층 무효화</h3>
+ * <p>{@code CompositeCacheManager.getCache()} 는 첫 번째 매니저(Caffeine)의 Cache 만 반환하므로,
+ * {@code @CacheEvict} 어노테이션만으로는 L2(Redis) 가 삭제되지 않는다.
+ * {@link #evict} 는 두 캐시 매니저에 각각 직접 evict 를 호출한다.
  */
+@Slf4j
 @Service
-@RequiredArgsConstructor
 public class MatchSnapshotCacheService {
 
     private final MatchRepository matchRepository;
+    private final CacheManager caffeineCacheManager;
+    private final CacheManager redisCacheManager;
+
+    public MatchSnapshotCacheService(
+            MatchRepository matchRepository,
+            @Qualifier("caffeineCacheManager") CacheManager caffeineCacheManager,
+            @Qualifier("redisCacheManager") CacheManager redisCacheManager
+    ) {
+        this.matchRepository = matchRepository;
+        this.caffeineCacheManager = caffeineCacheManager;
+        this.redisCacheManager = redisCacheManager;
+    }
 
     /**
-     * Match 스냅샷 조회 (캐시 우선).
+     * Match 스냅샷 조회 (캐시 우선, L1 → L2 → DB).
      *
-     * <p>{@code @Transactional(readOnly = true)} 는 캐시 미스 시 DB 조회에만 필요하다.
-     * 캐시 히트 시에는 트랜잭션이 열리지 않아 DB 커넥션을 소비하지 않는다.
+     * <p>{@code sync = true}: 캐시 미스 시 단 하나의 스레드만 DB 를 조회하고
+     * 나머지는 결과를 기다린다 — Cache Stampede 방지.
+     *
+     * <p>{@code @Transactional(readOnly = true)}: 캐시 미스 시 DB 조회에만 적용.
+     * 캐시 히트 시에는 트랜잭션이 열리지 않으므로 DB 커넥션을 소비하지 않는다.
      */
-    @Cacheable(value = MATCH_SNAPSHOT_CACHE, key = "#matchId")
+    @Cacheable(value = MATCH_SNAPSHOT_CACHE, key = "#matchId", sync = true)
     @Transactional(readOnly = true)
     public MatchSnapshot getSnapshot(UUID matchId) {
         Match match = matchRepository.findActiveByIdWithPolicies(matchId)
@@ -48,13 +77,29 @@ public class MatchSnapshotCacheService {
     }
 
     /**
-     * 캐시 무효화.
+     * L1(Caffeine) + L2(Redis) 양쪽 캐시 무효화.
      *
-     * <p>Match 또는 ZonePolicy 가 변경된 후 호출한다.
-     * 다음 {@link #getSnapshot} 호출 시 DB 에서 최신 데이터를 다시 로드한다.
+     * <p>{@code CompositeCacheManager} 는 {@code getCache()} 시 첫 번째 매니저(Caffeine) 만 반환하므로,
+     * {@code @CacheEvict} 단독으로는 Redis L2 가 삭제되지 않는다.
+     * 이 메서드는 두 캐시 매니저에 각각 직접 evict 를 호출하여 양쪽을 모두 무효화한다.
+     *
+     * <p>Redis 장애 시 {@link org.ticketing.match.infrastructure.config.MatchCacheConfig}
+     * 의 {@code CacheErrorHandler} 가 Redis evict 오류를 로깅 후 무시한다.
+     * L1(Caffeine) 은 항상 삭제되므로 TTL(5분) 이내에 최신 데이터가 L1 에서 제공된다.
      */
-    @CacheEvict(value = MATCH_SNAPSHOT_CACHE, key = "#matchId")
     public void evict(UUID matchId) {
-        // 어노테이션이 캐시 항목을 삭제한다. 메서드 본문은 비워도 된다.
+        evictFromManager(caffeineCacheManager, matchId, "L1-Caffeine");
+        evictFromManager(redisCacheManager, matchId, "L2-Redis");
+    }
+
+    private void evictFromManager(CacheManager manager, UUID matchId, String label) {
+        Cache cache = manager.getCache(MATCH_SNAPSHOT_CACHE);
+        if (cache != null) {
+            cache.evict(matchId);
+            log.debug("[Cache] {} evict — matchId={}", label, matchId);
+        } else {
+            log.warn("[Cache] {} getCache({}) 반환 null — evict 생략. matchId={}",
+                    label, MATCH_SNAPSHOT_CACHE, matchId);
+        }
     }
 }

--- a/src/main/java/org/ticketing/match/application/service/MatchSnapshotCacheService.java
+++ b/src/main/java/org/ticketing/match/application/service/MatchSnapshotCacheService.java
@@ -37,9 +37,9 @@ import static org.ticketing.match.infrastructure.config.MatchCacheConfig.MATCH_S
  * 이 서비스의 프록시 메서드({@link #getSnapshot})를 직접 호출해야 한다.
  *
  * <h3>Evict 양쪽 계층 무효화</h3>
- * <p>{@code CompositeCacheManager.getCache()} 는 첫 번째 매니저(Caffeine)의 Cache 만 반환하므로,
- * {@code @CacheEvict} 어노테이션만으로는 L2(Redis) 가 삭제되지 않는다.
- * {@link #evict} 는 두 캐시 매니저에 각각 직접 evict 를 호출한다.
+ * <p>Primary {@link CacheManager} 는 {@link TwoLevelCache} 를 통해 L1·L2 를 함께 관리하지만,
+ * {@link #evict} 는 각 매니저에 직접 evict 를 호출하여 명시적으로 양쪽을 무효화한다.
+ * 이를 통해 Primary 빈 교체 등의 구성 변경이 있어도 evict 동작이 보장된다.
  */
 @Slf4j
 @Service
@@ -79,9 +79,10 @@ public class MatchSnapshotCacheService {
     /**
      * L1(Caffeine) + L2(Redis) 양쪽 캐시 무효화.
      *
-     * <p>{@code CompositeCacheManager} 는 {@code getCache()} 시 첫 번째 매니저(Caffeine) 만 반환하므로,
-     * {@code @CacheEvict} 단독으로는 Redis L2 가 삭제되지 않는다.
-     * 이 메서드는 두 캐시 매니저에 각각 직접 evict 를 호출하여 양쪽을 모두 무효화한다.
+     * <p>각 캐시 매니저에 직접 evict 를 호출하여 L1·L2 를 명시적으로 무효화한다.
+     * Primary {@link org.springframework.cache.CacheManager} 가
+     * {@link org.ticketing.match.infrastructure.config.TwoLevelCache} 를 사용하더라도
+     * 내부 Cache 인스턴스는 공유되므로 직접 evict 와 동일한 효과를 낸다.
      *
      * <p>Redis 장애 시 {@link org.ticketing.match.infrastructure.config.MatchCacheConfig}
      * 의 {@code CacheErrorHandler} 가 Redis evict 오류를 로깅 후 무시한다.

--- a/src/main/java/org/ticketing/match/application/service/MatchWriteService.java
+++ b/src/main/java/org/ticketing/match/application/service/MatchWriteService.java
@@ -50,6 +50,7 @@ public class MatchWriteService {
     private final MatchRepository matchRepository;
     private final MatchEventPublisher matchEventPublisher;
     private final SeatAvailabilityRepository seatAvailabilityRepository;
+    private final MatchSnapshotCacheService matchSnapshotCacheService;
 
     // ──────────────────────────────────────────
     // Match 생성
@@ -66,6 +67,7 @@ public class MatchWriteService {
     public MatchResult update(UpdateMatchCommand command) {
         Match match = getActive(command.matchId());
         match.update(command.name(), command.matchDatetime(), command.ticketOpenAt());
+        matchSnapshotCacheService.evict(command.matchId());
         return MatchResult.from(match);
     }
 
@@ -125,12 +127,14 @@ public class MatchWriteService {
             );
         }
 
+        matchSnapshotCacheService.evict(command.matchId());
         return MatchResult.from(match);
     }
 
     public void delete(DeleteMatchCommand command) {
         Match match = getActive(command.matchId());
         match.delete(command.deletedBy());
+        matchSnapshotCacheService.evict(command.matchId());
     }
 
     // ──────────────────────────────────────────
@@ -141,18 +145,21 @@ public class MatchWriteService {
         Match match = getActive(command.matchId());
         MatchZonePolicy policy = match.addZonePolicy(command.seatGradeId(), command.price(), totalSeatCount);
         matchRepository.saveAndFlush(match);
+        matchSnapshotCacheService.evict(command.matchId());
         return MatchZonePolicyResult.from(policy);
     }
 
     public MatchZonePolicyResult updateZonePolicy(UpdateMatchZonePolicyCommand command) {
         Match match = getActive(command.matchId());
         match.updateZonePolicy(command.policyId(), command.price());
+        matchSnapshotCacheService.evict(command.matchId());
         return MatchZonePolicyResult.from(match.findZonePolicy(command.policyId()));
     }
 
     public void removeZonePolicy(RemoveMatchZonePolicyCommand command) {
         Match match = getActive(command.matchId());
         match.removeZonePolicy(command.policyId(), command.deletedBy());
+        matchSnapshotCacheService.evict(command.matchId());
     }
 
     // ──────────────────────────────────────────

--- a/src/main/java/org/ticketing/match/application/service/MatchWriteService.java
+++ b/src/main/java/org/ticketing/match/application/service/MatchWriteService.java
@@ -119,6 +119,20 @@ public class MatchWriteService {
                                 + "APPROVED 커밋은 완료됐으나 Redis 가 비어 있음. "
                                 + "수동 재초기화 또는 재승인 처리 필요.", matchId, e);
                     }
+                    // MatchSnapshot Cache Warm-up:
+                    // APPROVED 직후 첫 요청에서 Cache Stampede 가 발생하지 않도록
+                    // 커밋 후 즉시 캐시를 채운다.
+                    //
+                    // [중요] matchSnapshotCacheService 는 Spring 프록시 빈이므로
+                    // getSnapshot() 호출 시 @Cacheable AOP 가 정상 적용된다.
+                    // (warmUp() 같은 같은 클래스 내 self-invocation 이 아님)
+                    try {
+                        matchSnapshotCacheService.getSnapshot(matchId);
+                        log.info("[MatchWriteService] matchId={} MatchSnapshot 캐시 사전 적재 완료.", matchId);
+                    } catch (Exception e) {
+                        log.warn("[MatchWriteService] matchId={} MatchSnapshot 캐시 사전 적재 실패. "
+                                + "첫 요청에서 캐시 미스 발생 가능.", matchId, e);
+                    }
                 }
             });
         } else if (command.targetStatus() == MatchStatus.CANCELED) {

--- a/src/main/java/org/ticketing/match/application/service/SeatAvailabilityCacheService.java
+++ b/src/main/java/org/ticketing/match/application/service/SeatAvailabilityCacheService.java
@@ -1,63 +1,81 @@
 package org.ticketing.match.application.service;
 
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.ticketing.match.domain.repository.SeatAvailabilityRepository;
 
-import static org.ticketing.match.infrastructure.config.MatchCacheConfig.SEAT_REMAINING_CACHE;
-
 /**
- * 구역별 잔여 좌석 수를 Caffeine L1 으로 단기 캐싱하는 서비스.
+ * 구역별 잔여 좌석 수를 Caffeine {@link LoadingCache} 로 캐싱하는 서비스.
  *
- * <h3>설계 배경</h3>
- * <p>{@code seat:remaining:{matchId}} Redis Hash 는 예약/취소 시 원자적으로 DECR/INCR 되는
- * 실시간 데이터의 원본이다. 이 값에 L2(Redis) 캐시를 추가하면 원본과 캐시가 이중으로
- * Redis 에 존재하게 되므로 의미가 없다.
+ * <h3>expireAfterWrite → refreshAfterWrite 전환 이유</h3>
+ * <pre>
+ *   expireAfterWrite(2s)                     [이전]
+ *     TTL 만료 → 엔트리 삭제
+ *     다음 요청 → MISS → 1개 스레드 Redis 조회, 나머지 블로킹 대기
+ *     → 대기 스레드가 p90/p95 tail latency 로 누적
  *
- * <p>대신 Caffeine L1 캐시(TTL 2초)만 적용하여 다음 목적을 달성한다:
- * <ul>
- *   <li>티켓 오픈 순간 1,000+ req/s 가 동일 matchId 에 집중될 때
- *       Redis {@code HGETALL} 호출을 <b>2초당 1회</b>로 줄임 (Thundering Herd 완화)</li>
- *   <li>사용자 화면에 보여주는 잔여 좌석 표시는 2초 오차가 허용됨</li>
- *   <li>실제 예약 가능 여부 판단 및 좌석 차감은 reservation-service 의 Redis DECR 으로
- *       별도 처리되므로 정합성에 영향 없음</li>
- * </ul>
+ *   refreshAfterWrite(2s)                    [현재]
+ *     TTL 만료 → 엔트리 유지 (stale)
+ *     다음 요청 → 즉시 stale 값 반환 + 백그라운드에서 Redis 조회 트리거
+ *     → 사용자는 항상 L1 에서 즉시 반환 (~0ms), tail latency 제거
+ * </pre>
  *
- * <h3>Thundering Herd 방지</h3>
- * <p>{@code sync = true}: 2초 TTL 만료 시 다수의 스레드가 동시에 캐시 미스를 내더라도
- * 단 1개 스레드만 {@code HGETALL} 을 호출하고 나머지는 결과를 대기한다.
- * Caffeine 의 {@code cache.get(key, mappingFunction)} 이 JVM 내에서 이를 보장한다.
+ * <h3>Spring {@code @Cacheable} 대신 {@link LoadingCache} 직접 사용</h3>
+ * <p>{@code refreshAfterWrite} 는 Caffeine 의 {@link CacheLoader} 가 있는 {@link LoadingCache}
+ * 에서만 동작한다. Spring Cache 추상화는 이 조합을 지원하지 않으므로
+ * {@link LoadingCache} 를 생성자에서 직접 빌드한다.
  *
- * <h3>cacheManager 명시</h3>
- * <p>{@code cacheManager = "caffeineCacheManager"} 를 명시하여 기본 {@code CompositeCacheManager}
- * 를 우회한다. CompositeCacheManager 를 통하면 결과가 Redis L2 에도 기록되어
- * "Redis 가 원본이면서 동시에 캐시" 라는 이중 역할이 생기는 문제를 방지한다.
+ * <h3>최초 로드 (cold miss)</h3>
+ * <p>캐시에 엔트리가 없는 최초 요청은 {@link LoadingCache#get} 이 동기적으로 Redis 를 조회한다.
+ * 이후 TTL 만료 시 갱신은 {@code ForkJoinPool.commonPool()} 에서 비동기로 처리된다.
+ *
+ * <h3>백그라운드 갱신 실패</h3>
+ * <p>갱신 중 예외 발생 시 Caffeine 은 stale 값을 유지하고 다음 주기에 재시도한다.
+ * 잔여 좌석 표시용이므로 일시적 stale 은 허용 범위 내에 있다.
+ *
+ * <h3>Redis 원본과의 관계</h3>
+ * <p>{@code seat:remaining:{matchId}} Redis Hash 는 reservation-service 의 DECR/INCR 이
+ * 원자적으로 갱신하는 실시간 원본이다. 이 캐시는 표시용 읽기 전용이며,
+ * 실제 예약 가능 여부는 reservation-service 의 Redis DECR 이 단독으로 판단한다.
  */
 @Service
-@RequiredArgsConstructor
 public class SeatAvailabilityCacheService {
 
-    private final SeatAvailabilityRepository seatAvailabilityRepository;
+    private final LoadingCache<UUID, Map<UUID, Long>> cache;
 
     /**
-     * 경기의 구역별 잔여 좌석 수 조회 (Caffeine L1 캐시, TTL 2초).
+     * 생성자에서 {@link LoadingCache} 를 직접 빌드한다.
      *
-     * <p>캐시 히트 시 Redis 조회 없이 JVM 메모리에서 즉시 반환.
-     * 캐시 미스(2초마다 1회) 시 {@code HGETALL seat:remaining:{matchId}} 를 Redis 에서 조회.
+     * <p>{@code refreshAfterWrite(2s)}: TTL 만료 후 첫 요청 시 stale 값을 즉시 반환하고
+     * {@code seatAvailabilityRepository::findAll} 을 백그라운드에서 비동기 실행한다.
+     *
+     * @param seatAvailabilityRepository Redis {@code HGETALL} 을 수행하는 레포지토리.
+     *                                   메서드 레퍼런스로 {@link CacheLoader} 에 직접 연결.
+     */
+    public SeatAvailabilityCacheService(SeatAvailabilityRepository seatAvailabilityRepository) {
+        this.cache = Caffeine.newBuilder()
+                .maximumSize(1_000)
+                .refreshAfterWrite(Duration.ofSeconds(2))
+                .recordStats()
+                .build(seatAvailabilityRepository::findAll);
+    }
+
+    /**
+     * 경기의 구역별 잔여 좌석 수 조회.
+     *
+     * <p>캐시 히트(fresh / stale): JVM 메모리에서 즉시 반환 (~0ms).
+     * 캐시 미스(최초 요청): Redis {@code HGETALL seat:remaining:{matchId}} 동기 조회.
+     * TTL 만료 후: stale 즉시 반환 + 백그라운드 갱신.
      *
      * @param matchId 경기 ID
      * @return seatGradeId → 잔여 좌석 수 맵
      */
-    @Cacheable(
-            value = SEAT_REMAINING_CACHE,
-            key = "#matchId",
-            sync = true,
-            cacheManager = "caffeineCacheManager"
-    )
     public Map<UUID, Long> getRemaining(UUID matchId) {
-        return seatAvailabilityRepository.findAll(matchId);
+        return cache.get(matchId);
     }
 }

--- a/src/main/java/org/ticketing/match/application/service/SeatAvailabilityCacheService.java
+++ b/src/main/java/org/ticketing/match/application/service/SeatAvailabilityCacheService.java
@@ -1,42 +1,23 @@
 package org.ticketing.match.application.service;
 
-import com.github.benmanes.caffeine.cache.CacheLoader;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.LoadingCache;
-import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.ticketing.match.domain.repository.SeatAvailabilityRepository;
+import org.ticketing.match.infrastructure.config.MatchCacheConfig;
 
 /**
- * 구역별 잔여 좌석 수를 Caffeine {@link LoadingCache} 로 캐싱하는 서비스.
+ * 구역별 잔여 좌석 수를 Caffeine L1 캐시로 캐싱하는 서비스.
  *
- * <h3>expireAfterWrite → refreshAfterWrite 전환 이유</h3>
+ * <h3>캐시 전략</h3>
  * <pre>
- *   expireAfterWrite(2s)                     [이전]
+ *   expireAfterWrite(2s) + @Cacheable(sync=true)
  *     TTL 만료 → 엔트리 삭제
- *     다음 요청 → MISS → 1개 스레드 Redis 조회, 나머지 블로킹 대기
- *     → 대기 스레드가 p90/p95 tail latency 로 누적
- *
- *   refreshAfterWrite(2s)                    [현재]
- *     TTL 만료 → 엔트리 유지 (stale)
- *     다음 요청 → 즉시 stale 값 반환 + 백그라운드에서 Redis 조회 트리거
- *     → 사용자는 항상 L1 에서 즉시 반환 (~0ms), tail latency 제거
+ *     다음 요청 → MISS → 1개 스레드만 Redis 조회, 나머지는 lock 대기 (stampede 방지)
+ *     조회 완료 → 2초간 L1 에서 즉시 반환
  * </pre>
- *
- * <h3>Spring {@code @Cacheable} 대신 {@link LoadingCache} 직접 사용</h3>
- * <p>{@code refreshAfterWrite} 는 Caffeine 의 {@link CacheLoader} 가 있는 {@link LoadingCache}
- * 에서만 동작한다. Spring Cache 추상화는 이 조합을 지원하지 않으므로
- * {@link LoadingCache} 를 생성자에서 직접 빌드한다.
- *
- * <h3>최초 로드 (cold miss)</h3>
- * <p>캐시에 엔트리가 없는 최초 요청은 {@link LoadingCache#get} 이 동기적으로 Redis 를 조회한다.
- * 이후 TTL 만료 시 갱신은 {@code ForkJoinPool.commonPool()} 에서 비동기로 처리된다.
- *
- * <h3>백그라운드 갱신 실패</h3>
- * <p>갱신 중 예외 발생 시 Caffeine 은 stale 값을 유지하고 다음 주기에 재시도한다.
- * 잔여 좌석 표시용이므로 일시적 stale 은 허용 범위 내에 있다.
  *
  * <h3>Redis 원본과의 관계</h3>
  * <p>{@code seat:remaining:{matchId}} Redis Hash 는 reservation-service 의 DECR/INCR 이
@@ -44,38 +25,23 @@ import org.ticketing.match.domain.repository.SeatAvailabilityRepository;
  * 실제 예약 가능 여부는 reservation-service 의 Redis DECR 이 단독으로 판단한다.
  */
 @Service
+@RequiredArgsConstructor
 public class SeatAvailabilityCacheService {
 
-    private final LoadingCache<UUID, Map<UUID, Long>> cache;
-
-    /**
-     * 생성자에서 {@link LoadingCache} 를 직접 빌드한다.
-     *
-     * <p>{@code refreshAfterWrite(2s)}: TTL 만료 후 첫 요청 시 stale 값을 즉시 반환하고
-     * {@code seatAvailabilityRepository::findAll} 을 백그라운드에서 비동기 실행한다.
-     *
-     * @param seatAvailabilityRepository Redis {@code HGETALL} 을 수행하는 레포지토리.
-     *                                   메서드 레퍼런스로 {@link CacheLoader} 에 직접 연결.
-     */
-    public SeatAvailabilityCacheService(SeatAvailabilityRepository seatAvailabilityRepository) {
-        this.cache = Caffeine.newBuilder()
-                .maximumSize(1_000)
-                .refreshAfterWrite(Duration.ofSeconds(2))
-                .recordStats()
-                .build(seatAvailabilityRepository::findAll);
-    }
+    private final SeatAvailabilityRepository seatAvailabilityRepository;
 
     /**
      * 경기의 구역별 잔여 좌석 수 조회.
      *
-     * <p>캐시 히트(fresh / stale): JVM 메모리에서 즉시 반환 (~0ms).
-     * 캐시 미스(최초 요청): Redis {@code HGETALL seat:remaining:{matchId}} 동기 조회.
-     * TTL 만료 후: stale 즉시 반환 + 백그라운드 갱신.
+     * <p>캐시 히트: Caffeine L1 에서 즉시 반환 (~0ms).
+     * 캐시 미스: Redis {@code HGETALL seat:remaining:{matchId}} 동기 조회.
+     * {@code sync=true} 로 단일 로더만 Redis 를 조회하고 나머지는 대기(stampede 방지).
      *
      * @param matchId 경기 ID
      * @return seatGradeId → 잔여 좌석 수 맵
      */
+    @Cacheable(value = MatchCacheConfig.SEAT_REMAINING_CACHE, key = "#matchId", sync = true)
     public Map<UUID, Long> getRemaining(UUID matchId) {
-        return cache.get(matchId);
+        return seatAvailabilityRepository.findAll(matchId);
     }
 }

--- a/src/main/java/org/ticketing/match/application/service/SeatAvailabilityCacheService.java
+++ b/src/main/java/org/ticketing/match/application/service/SeatAvailabilityCacheService.java
@@ -1,0 +1,63 @@
+package org.ticketing.match.application.service;
+
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.ticketing.match.domain.repository.SeatAvailabilityRepository;
+
+import static org.ticketing.match.infrastructure.config.MatchCacheConfig.SEAT_REMAINING_CACHE;
+
+/**
+ * 구역별 잔여 좌석 수를 Caffeine L1 으로 단기 캐싱하는 서비스.
+ *
+ * <h3>설계 배경</h3>
+ * <p>{@code seat:remaining:{matchId}} Redis Hash 는 예약/취소 시 원자적으로 DECR/INCR 되는
+ * 실시간 데이터의 원본이다. 이 값에 L2(Redis) 캐시를 추가하면 원본과 캐시가 이중으로
+ * Redis 에 존재하게 되므로 의미가 없다.
+ *
+ * <p>대신 Caffeine L1 캐시(TTL 2초)만 적용하여 다음 목적을 달성한다:
+ * <ul>
+ *   <li>티켓 오픈 순간 1,000+ req/s 가 동일 matchId 에 집중될 때
+ *       Redis {@code HGETALL} 호출을 <b>2초당 1회</b>로 줄임 (Thundering Herd 완화)</li>
+ *   <li>사용자 화면에 보여주는 잔여 좌석 표시는 2초 오차가 허용됨</li>
+ *   <li>실제 예약 가능 여부 판단 및 좌석 차감은 reservation-service 의 Redis DECR 으로
+ *       별도 처리되므로 정합성에 영향 없음</li>
+ * </ul>
+ *
+ * <h3>Thundering Herd 방지</h3>
+ * <p>{@code sync = true}: 2초 TTL 만료 시 다수의 스레드가 동시에 캐시 미스를 내더라도
+ * 단 1개 스레드만 {@code HGETALL} 을 호출하고 나머지는 결과를 대기한다.
+ * Caffeine 의 {@code cache.get(key, mappingFunction)} 이 JVM 내에서 이를 보장한다.
+ *
+ * <h3>cacheManager 명시</h3>
+ * <p>{@code cacheManager = "caffeineCacheManager"} 를 명시하여 기본 {@code CompositeCacheManager}
+ * 를 우회한다. CompositeCacheManager 를 통하면 결과가 Redis L2 에도 기록되어
+ * "Redis 가 원본이면서 동시에 캐시" 라는 이중 역할이 생기는 문제를 방지한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class SeatAvailabilityCacheService {
+
+    private final SeatAvailabilityRepository seatAvailabilityRepository;
+
+    /**
+     * 경기의 구역별 잔여 좌석 수 조회 (Caffeine L1 캐시, TTL 2초).
+     *
+     * <p>캐시 히트 시 Redis 조회 없이 JVM 메모리에서 즉시 반환.
+     * 캐시 미스(2초마다 1회) 시 {@code HGETALL seat:remaining:{matchId}} 를 Redis 에서 조회.
+     *
+     * @param matchId 경기 ID
+     * @return seatGradeId → 잔여 좌석 수 맵
+     */
+    @Cacheable(
+            value = SEAT_REMAINING_CACHE,
+            key = "#matchId",
+            sync = true,
+            cacheManager = "caffeineCacheManager"
+    )
+    public Map<UUID, Long> getRemaining(UUID matchId) {
+        return seatAvailabilityRepository.findAll(matchId);
+    }
+}

--- a/src/main/java/org/ticketing/match/domain/repository/MatchRepository.java
+++ b/src/main/java/org/ticketing/match/domain/repository/MatchRepository.java
@@ -17,4 +17,10 @@ public interface MatchRepository {
     Optional<Match> findById(UUID id);
 
     Optional<Match> findActiveById(UUID id);
+
+    /**
+     * ZonePolicy 를 fetch join 으로 함께 조회한다.
+     * MatchSnapshotCacheService 가 캐시 미스 시에만 호출한다.
+     */
+    Optional<Match> findActiveByIdWithPolicies(UUID id);
 }

--- a/src/main/java/org/ticketing/match/infrastructure/config/MatchCacheConfig.java
+++ b/src/main/java/org/ticketing/match/infrastructure/config/MatchCacheConfig.java
@@ -2,7 +2,6 @@ package org.ticketing.match.infrastructure.config;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.time.Duration;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -31,9 +30,9 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
  *   match-snapshot  : Match + ZonePolicy 정적 구조 데이터
  *                     L1(Caffeine 5분) → L2(Redis 60분) → DB(fetch join)
  *
- *   seat-remaining  : 구역별 잔여 좌석 수 표시용 스냅샷
- *                     L1(Caffeine 2초) 전용 — Redis 는 원본 데이터이므로 L2 캐시 없음
- *                     TTL 2초: Thundering Herd to Redis 완화, 허용 가능한 표시 지연
+ *   seat-remaining  : {@link org.ticketing.match.application.service.SeatAvailabilityCacheService} 참조.
+ *                     Caffeine {@code LoadingCache} 를 직접 사용(stale-while-revalidate)하므로
+ *                     Spring Cache 추상화에는 등록하지 않는다.
  * </pre>
  *
  * <h3>Caffeine 계층 구조 (match-snapshot)</h3>
@@ -45,15 +44,6 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
  *          DB (fetch join, ~10ms)
  * </pre>
  *
- * <h3>seat-remaining 캐시 구조</h3>
- * <pre>
- *   요청 → Caffeine (L1, 2초 TTL, ~0ms)
- *            ↓ miss (2초마다 1회)
- *          Redis Hash HGETALL (원본, ~1ms)
- *
- *   sync=true: TTL 만료 시 단 1개 스레드만 Redis 조회 → Thundering Herd 방지
- * </pre>
- *
  * <h3>Redis 장애 시 동작 (match-snapshot)</h3>
  * <ul>
  *   <li>Caffeine L1 히트 → Redis 없이도 서비스 유지.</li>
@@ -61,10 +51,9 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
  *   <li>Redis 복구 후 → 다음 캐시 미스 시 Redis 에 자동 재적재.</li>
  * </ul>
  *
- * <h3>Cache Stampede / Thundering Herd 방지</h3>
+ * <h3>Cache Stampede / Thundering Herd 방지 (match-snapshot)</h3>
  * <ul>
- *   <li>match-snapshot: Caffeine {@code computeIfAbsent} + {@code @Cacheable(sync=true)} 로 단일 로더 보장.</li>
- *   <li>seat-remaining: Caffeine {@code computeIfAbsent} + {@code @Cacheable(sync=true)} 로 2초마다 Redis 조회 1회로 제한.</li>
+ *   <li>Caffeine {@code computeIfAbsent} + {@code @Cacheable(sync=true)} 로 단일 로더 보장.</li>
  * </ul>
  */
 @Slf4j
@@ -74,28 +63,15 @@ public class MatchCacheConfig implements CachingConfigurer {
 
     public static final String MATCH_SNAPSHOT_CACHE = "match-snapshot";
 
-    /**
-     * 잔여 좌석 표시용 캐시.
-     *
-     * <p>Redis Hash({@code seat:remaining:{matchId}}) 가 원본이므로 L2(Redis) 캐시는 사용하지 않는다.
-     * Caffeine L1 만 사용하며, TTL 2초로 Thundering Herd 를 완화한다.
-     * 사용 시 {@code @Cacheable(cacheManager = "caffeineCacheManager")} 로 지정해
-     * {@link CompositeCacheManager} 를 우회해야 한다.
-     */
-    public static final String SEAT_REMAINING_CACHE = "seat-remaining";
-
-    // ── L1: Caffeine (캐시별 TTL 분리) ───────────────────────────────────────
+    // ── L1: Caffeine (match-snapshot 전용) ───────────────────────────────────
 
     /**
-     * Caffeine L1 캐시 매니저.
+     * Caffeine L1 캐시 매니저 ({@code match-snapshot} 전용).
      *
-     * <p>캐시마다 TTL 이 다르므로 {@link CaffeineCache} 를 직접 생성하고
-     * {@link SimpleCacheManager} 로 묶는다.
+     * <p>TTL 5분: Redis L2(60분) 보다 짧게 설정해 L1 만료 후 L2 에서 최신 값을 확인한다.
      *
-     * <ul>
-     *   <li>{@code match-snapshot}: TTL 5분 — Redis L2 보다 짧게 설정해 L1 만료 후 L2 에서 최신 값 확인</li>
-     *   <li>{@code seat-remaining}: TTL 2초 — 표시용 허용 오차, Redis 조회를 2초당 1회로 제한</li>
-     * </ul>
+     * <p>{@code seat-remaining} 은 {@link org.ticketing.match.application.service.SeatAvailabilityCacheService}
+     * 에서 Caffeine {@code LoadingCache} 로 직접 관리하므로 여기에 등록하지 않는다.
      */
     @Bean("caffeineCacheManager")
     public CacheManager caffeineCacheManager() {
@@ -108,17 +84,8 @@ public class MatchCacheConfig implements CachingConfigurer {
                         .build()
         );
 
-        CaffeineCache seatRemainingCache = new CaffeineCache(
-                SEAT_REMAINING_CACHE,
-                Caffeine.newBuilder()
-                        .maximumSize(1_000)                    // 경기 1,000개 상한
-                        .expireAfterWrite(Duration.ofSeconds(2)) // 표시용 허용 오차 2초
-                        .recordStats()
-                        .build()
-        );
-
         SimpleCacheManager manager = new SimpleCacheManager();
-        manager.setCaches(List.of(matchSnapshotCache, seatRemainingCache));
+        manager.setCaches(List.of(matchSnapshotCache));
         return manager;
     }
 
@@ -155,9 +122,7 @@ public class MatchCacheConfig implements CachingConfigurer {
     /**
      * {@link CompositeCacheManager}: L1(Caffeine) → L2(Redis) 순서로 조회.
      *
-     * <p>{@code match-snapshot} 에만 사용한다.
-     * {@code seat-remaining} 은 {@code @Cacheable(cacheManager = "caffeineCacheManager")} 로
-     * 이 매니저를 우회하여 Caffeine 전용으로 동작한다.
+     * <p>{@code match-snapshot} 전용. L1 미스 시 L2(Redis) 에서 자동으로 값을 조회한다.
      */
     @Bean
     @Primary

--- a/src/main/java/org/ticketing/match/infrastructure/config/MatchCacheConfig.java
+++ b/src/main/java/org/ticketing/match/infrastructure/config/MatchCacheConfig.java
@@ -2,6 +2,7 @@ package org.ticketing.match.infrastructure.config;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.time.Duration;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -30,9 +31,9 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
  *   match-snapshot  : Match + ZonePolicy 정적 구조 데이터
  *                     L1(Caffeine 5분) → L2(Redis 60분) → DB(fetch join)
  *
- *   seat-remaining  : {@link org.ticketing.match.application.service.SeatAvailabilityCacheService} 참조.
- *                     Caffeine {@code LoadingCache} 를 직접 사용(stale-while-revalidate)하므로
- *                     Spring Cache 추상화에는 등록하지 않는다.
+ *   seat-remaining  : 구역별 잔여 좌석 수. L1(Caffeine 2초) → Redis(원본) 구조.
+ *                     {@code @Cacheable(sync=true)} + {@code expireAfterWrite(2s)} 로 stampede 방지.
+ *                     Redis 가 원본이므로 L2 Redis 캐시 미등록.
  * </pre>
  *
  * <h3>Caffeine 계층 구조 (match-snapshot)</h3>
@@ -62,16 +63,18 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class MatchCacheConfig implements CachingConfigurer {
 
     public static final String MATCH_SNAPSHOT_CACHE = "match-snapshot";
+    public static final String SEAT_REMAINING_CACHE = "seat-remaining";
 
-    // ── L1: Caffeine (match-snapshot 전용) ───────────────────────────────────
+    // ── L1: Caffeine ─────────────────────────────────────────────────────────
 
     /**
-     * Caffeine L1 캐시 매니저 ({@code match-snapshot} 전용).
+     * Caffeine L1 캐시 매니저.
      *
-     * <p>TTL 5분: Redis L2(60분) 보다 짧게 설정해 L1 만료 후 L2 에서 최신 값을 확인한다.
-     *
-     * <p>{@code seat-remaining} 은 {@link org.ticketing.match.application.service.SeatAvailabilityCacheService}
-     * 에서 Caffeine {@code LoadingCache} 로 직접 관리하므로 여기에 등록하지 않는다.
+     * <ul>
+     *   <li>{@code match-snapshot}: TTL 5분 — Redis L2(60분) 보다 짧게 설정해 L1 만료 후 L2 에서 최신 값을 확인.</li>
+     *   <li>{@code seat-remaining}: TTL 2초 — reservation-service 의 Redis DECR/INCR 이 원본.
+     *       {@code @Cacheable(sync=true)} 로 stampede 방지. Redis L2 미등록(원본이 Redis 이므로).</li>
+     * </ul>
      */
     @Bean("caffeineCacheManager")
     public CacheManager caffeineCacheManager() {
@@ -84,8 +87,17 @@ public class MatchCacheConfig implements CachingConfigurer {
                         .build()
         );
 
+        CaffeineCache seatRemainingCache = new CaffeineCache(
+                SEAT_REMAINING_CACHE,
+                Caffeine.newBuilder()
+                        .maximumSize(1_000)
+                        .expireAfterWrite(Duration.ofSeconds(2))
+                        .recordStats()
+                        .build()
+        );
+
         SimpleCacheManager manager = new SimpleCacheManager();
-        manager.setCaches(List.of(matchSnapshotCache));
+        manager.setCaches(List.of(matchSnapshotCache, seatRemainingCache));
         return manager;
     }
 

--- a/src/main/java/org/ticketing/match/infrastructure/config/MatchCacheConfig.java
+++ b/src/main/java/org/ticketing/match/infrastructure/config/MatchCacheConfig.java
@@ -1,0 +1,52 @@
+package org.ticketing.match.infrastructure.config;
+
+import java.time.Duration;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * Spring Cache → Redis 연동 설정.
+ *
+ * <p>캐시 이름별 TTL:
+ * <ul>
+ *   <li>{@code match-snapshot} : 10분 — Match + ZonePolicy 정적 데이터 (관리자 변경 시 evict)</li>
+ * </ul>
+ *
+ * <p>직렬화: {@link GenericJackson2JsonRedisSerializer} (JSON + 타입 정보 포함)
+ * → record 타입을 역직렬화할 때도 정확한 타입으로 복원된다.
+ */
+@Configuration
+@EnableCaching
+public class MatchCacheConfig {
+
+    public static final String MATCH_SNAPSHOT_CACHE = "match-snapshot";
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory factory) {
+        GenericJackson2JsonRedisSerializer jsonSerializer =
+                new GenericJackson2JsonRedisSerializer();
+
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10))
+                .disableCachingNullValues()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(jsonSerializer));
+
+        RedisCacheConfiguration snapshotConfig = defaultConfig
+                .entryTtl(Duration.ofMinutes(10));
+
+        return RedisCacheManager.builder(factory)
+                .cacheDefaults(defaultConfig)
+                .withCacheConfiguration(MATCH_SNAPSHOT_CACHE, snapshotConfig)
+                .build();
+    }
+}

--- a/src/main/java/org/ticketing/match/infrastructure/config/MatchCacheConfig.java
+++ b/src/main/java/org/ticketing/match/infrastructure/config/MatchCacheConfig.java
@@ -1,7 +1,16 @@
 package org.ticketing.match.infrastructure.config;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
 import java.time.Duration;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cache.support.CompositeCacheManager;
+import org.springframework.cache.support.SimpleCacheErrorHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
@@ -10,43 +19,141 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.cache.annotation.CachingConfigurer;
+import org.springframework.cache.interceptor.CacheErrorHandler;
 
 /**
- * Spring Cache → Redis 연동 설정.
+ * L1(Caffeine) + L2(Redis) 2계층 캐시 구성.
  *
- * <p>캐시 이름별 TTL:
+ * <h3>계층 구조</h3>
+ * <pre>
+ *   요청 → Caffeine (L1, JVM 메모리, ~0ms)
+ *            ↓ miss
+ *          Redis (L2, 네트워크 캐시, ~1ms)
+ *            ↓ miss
+ *          DB (fetch join, ~10ms)
+ * </pre>
+ *
+ * <h3>Redis 장애 시 동작</h3>
  * <ul>
- *   <li>{@code match-snapshot} : 10분 — Match + ZonePolicy 정적 데이터 (관리자 변경 시 evict)</li>
+ *   <li>{@link RedisCacheErrorHandler} 가 Redis 오류를 로깅 후 무시한다.</li>
+ *   <li>Caffeine L1 히트 → Redis 없이도 서비스 유지.</li>
+ *   <li>Caffeine L1 미스 → DB 직접 조회 (Redis 기록 생략).</li>
+ *   <li>Redis 복구 후 → 다음 캐시 미스 시 Redis 에 자동 재적재.</li>
  * </ul>
  *
- * <p>직렬화: {@link GenericJackson2JsonRedisSerializer} (JSON + 타입 정보 포함)
- * → record 타입을 역직렬화할 때도 정확한 타입으로 복원된다.
+ * <h3>Cache Stampede 방지</h3>
+ * <ul>
+ *   <li>Caffeine: {@link Caffeine#maximumSize} + expireAfterWrite 로 JVM 내 단일 로더 보장.</li>
+ *   <li>Redis: {@code @Cacheable(sync = true)} 로 동시 DB 조회를 단일 스레드로 직렬화.</li>
+ * </ul>
  */
+@Slf4j
 @Configuration
 @EnableCaching
-public class MatchCacheConfig {
+public class MatchCacheConfig implements CachingConfigurer {
 
     public static final String MATCH_SNAPSHOT_CACHE = "match-snapshot";
 
-    @Bean
-    public RedisCacheManager cacheManager(RedisConnectionFactory factory) {
+    // ── L1: Caffeine ──────────────────────────────────────────────────────────
+
+    /**
+     * Caffeine L1 캐시 매니저.
+     *
+     * <p>TTL 5분: Redis 보다 짧게 설정해 L1 만료 후 Redis(L2) 에서 최신 값을 확인한다.
+     * {@code @CacheEvict} 는 {@link CompositeCacheManager} 를 통해 L1·L2 모두 무효화한다.
+     */
+    @Bean("caffeineCacheManager")
+    public CacheManager caffeineCacheManager() {
+        CaffeineCacheManager manager = new CaffeineCacheManager(MATCH_SNAPSHOT_CACHE);
+        manager.setCaffeine(
+                Caffeine.newBuilder()
+                        .maximumSize(1_000)          // 경기 1,000개 상한
+                        .expireAfterWrite(Duration.ofMinutes(5))
+                        .recordStats()               // 캐시 히트율 모니터링
+        );
+        return manager;
+    }
+
+    // ── L2: Redis ─────────────────────────────────────────────────────────────
+
+    /**
+     * Redis L2 캐시 매니저.
+     *
+     * <p>TTL 60분: {@code @CacheEvict} 가 정확성을 보장하므로 TTL 은 안전망.
+     * Redis 장애 시 {@link RedisCacheErrorHandler} 가 오류를 무시하여 L1 으로 폴백.
+     */
+    @Bean("redisCacheManager")
+    public CacheManager redisCacheManager(RedisConnectionFactory factory) {
         GenericJackson2JsonRedisSerializer jsonSerializer =
                 new GenericJackson2JsonRedisSerializer();
 
-        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofMinutes(10))
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(60))
                 .disableCachingNullValues()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair
                         .fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair
                         .fromSerializer(jsonSerializer));
 
-        RedisCacheConfiguration snapshotConfig = defaultConfig
-                .entryTtl(Duration.ofMinutes(10));
-
         return RedisCacheManager.builder(factory)
-                .cacheDefaults(defaultConfig)
-                .withCacheConfiguration(MATCH_SNAPSHOT_CACHE, snapshotConfig)
+                .cacheDefaults(config)
+                .withCacheConfiguration(MATCH_SNAPSHOT_CACHE, config)
                 .build();
+    }
+
+    // ── Composite: L1 → L2 순서 조회 ─────────────────────────────────────────
+
+    /**
+     * {@link CompositeCacheManager}: L1(Caffeine) → L2(Redis) 순서로 조회.
+     *
+     * <p>Spring {@code @Cacheable} 은 이 매니저를 사용한다.
+     * L1 히트 시 L2 조회 생략 → Redis 네트워크 왕복 0회.
+     * L1 미스 → L2 조회 → 히트 시 L1 에도 자동 저장.
+     */
+    @Bean
+    public CacheManager cacheManager(
+            CacheManager caffeineCacheManager,
+            CacheManager redisCacheManager
+    ) {
+        CompositeCacheManager composite = new CompositeCacheManager(
+                caffeineCacheManager,
+                redisCacheManager
+        );
+        composite.setFallbackToNoOpCache(false); // 캐시 미스 시 DB 조회 보장
+        return composite;
+    }
+
+    // ── Redis 오류 핸들러 ─────────────────────────────────────────────────────
+
+    /**
+     * Redis 장애 시 예외를 삼키고 DB 또는 L1 캐시로 폴백한다.
+     *
+     * <p>기본 {@link SimpleCacheErrorHandler} 는 예외를 그대로 전파하여 서비스 장애로 이어진다.
+     * 이 핸들러는 Redis 오류를 WARN 로그로만 기록하고 계속 진행한다.
+     */
+    @Bean
+    public CacheErrorHandler errorHandler() {
+        return new SimpleCacheErrorHandler() {
+            @Override
+            public void handleCacheGetError(RuntimeException e, Cache cache, Object key) {
+                log.warn("[Cache] Redis GET 실패 — cache={}, key={}, 원인={}", cache.getName(), key, e.getMessage());
+            }
+
+            @Override
+            public void handleCachePutError(RuntimeException e, Cache cache, Object key, Object value) {
+                log.warn("[Cache] Redis PUT 실패 — cache={}, key={}, 원인={}", cache.getName(), key, e.getMessage());
+            }
+
+            @Override
+            public void handleCacheEvictError(RuntimeException e, Cache cache, Object key) {
+                log.warn("[Cache] Redis EVICT 실패 — cache={}, key={}, 원인={}", cache.getName(), key, e.getMessage());
+            }
+
+            @Override
+            public void handleCacheClearError(RuntimeException e, Cache cache) {
+                log.warn("[Cache] Redis CLEAR 실패 — cache={}, 원인={}", cache.getName(), e.getMessage());
+            }
+        };
     }
 }

--- a/src/main/java/org/ticketing/match/infrastructure/config/MatchCacheConfig.java
+++ b/src/main/java/org/ticketing/match/infrastructure/config/MatchCacheConfig.java
@@ -6,11 +6,13 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CachingConfigurer;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCache;
-import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cache.interceptor.CacheErrorHandler;
 import org.springframework.cache.support.CompositeCacheManager;
 import org.springframework.cache.support.SimpleCacheErrorHandler;
+import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
@@ -19,13 +21,21 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-import org.springframework.cache.annotation.CachingConfigurer;
-import org.springframework.cache.interceptor.CacheErrorHandler;
 
 /**
  * L1(Caffeine) + L2(Redis) 2계층 캐시 구성.
  *
- * <h3>계층 구조</h3>
+ * <h3>캐시 목록</h3>
+ * <pre>
+ *   match-snapshot  : Match + ZonePolicy 정적 구조 데이터
+ *                     L1(Caffeine 5분) → L2(Redis 60분) → DB(fetch join)
+ *
+ *   seat-remaining  : 구역별 잔여 좌석 수 표시용 스냅샷
+ *                     L1(Caffeine 2초) 전용 — Redis 는 원본 데이터이므로 L2 캐시 없음
+ *                     TTL 2초: Thundering Herd to Redis 완화, 허용 가능한 표시 지연
+ * </pre>
+ *
+ * <h3>Caffeine 계층 구조 (match-snapshot)</h3>
  * <pre>
  *   요청 → Caffeine (L1, JVM 메모리, ~0ms)
  *            ↓ miss
@@ -34,18 +44,26 @@ import org.springframework.cache.interceptor.CacheErrorHandler;
  *          DB (fetch join, ~10ms)
  * </pre>
  *
- * <h3>Redis 장애 시 동작</h3>
+ * <h3>seat-remaining 캐시 구조</h3>
+ * <pre>
+ *   요청 → Caffeine (L1, 2초 TTL, ~0ms)
+ *            ↓ miss (2초마다 1회)
+ *          Redis Hash HGETALL (원본, ~1ms)
+ *
+ *   sync=true: TTL 만료 시 단 1개 스레드만 Redis 조회 → Thundering Herd 방지
+ * </pre>
+ *
+ * <h3>Redis 장애 시 동작 (match-snapshot)</h3>
  * <ul>
- *   <li>{@link RedisCacheErrorHandler} 가 Redis 오류를 로깅 후 무시한다.</li>
  *   <li>Caffeine L1 히트 → Redis 없이도 서비스 유지.</li>
  *   <li>Caffeine L1 미스 → DB 직접 조회 (Redis 기록 생략).</li>
  *   <li>Redis 복구 후 → 다음 캐시 미스 시 Redis 에 자동 재적재.</li>
  * </ul>
  *
- * <h3>Cache Stampede 방지</h3>
+ * <h3>Cache Stampede / Thundering Herd 방지</h3>
  * <ul>
- *   <li>Caffeine: {@link Caffeine#maximumSize} + expireAfterWrite 로 JVM 내 단일 로더 보장.</li>
- *   <li>Redis: {@code @Cacheable(sync = true)} 로 동시 DB 조회를 단일 스레드로 직렬화.</li>
+ *   <li>match-snapshot: Caffeine {@code computeIfAbsent} + {@code @Cacheable(sync=true)} 로 단일 로더 보장.</li>
+ *   <li>seat-remaining: Caffeine {@code computeIfAbsent} + {@code @Cacheable(sync=true)} 로 2초마다 Redis 조회 1회로 제한.</li>
  * </ul>
  */
 @Slf4j
@@ -55,33 +73,61 @@ public class MatchCacheConfig implements CachingConfigurer {
 
     public static final String MATCH_SNAPSHOT_CACHE = "match-snapshot";
 
-    // ── L1: Caffeine ──────────────────────────────────────────────────────────
+    /**
+     * 잔여 좌석 표시용 캐시.
+     *
+     * <p>Redis Hash({@code seat:remaining:{matchId}}) 가 원본이므로 L2(Redis) 캐시는 사용하지 않는다.
+     * Caffeine L1 만 사용하며, TTL 2초로 Thundering Herd 를 완화한다.
+     * 사용 시 {@code @Cacheable(cacheManager = "caffeineCacheManager")} 로 지정해
+     * {@link CompositeCacheManager} 를 우회해야 한다.
+     */
+    public static final String SEAT_REMAINING_CACHE = "seat-remaining";
+
+    // ── L1: Caffeine (캐시별 TTL 분리) ───────────────────────────────────────
 
     /**
      * Caffeine L1 캐시 매니저.
      *
-     * <p>TTL 5분: Redis 보다 짧게 설정해 L1 만료 후 Redis(L2) 에서 최신 값을 확인한다.
-     * {@code @CacheEvict} 는 {@link CompositeCacheManager} 를 통해 L1·L2 모두 무효화한다.
+     * <p>캐시마다 TTL 이 다르므로 {@link CaffeineCache} 를 직접 생성하고
+     * {@link SimpleCacheManager} 로 묶는다.
+     *
+     * <ul>
+     *   <li>{@code match-snapshot}: TTL 5분 — Redis L2 보다 짧게 설정해 L1 만료 후 L2 에서 최신 값 확인</li>
+     *   <li>{@code seat-remaining}: TTL 2초 — 표시용 허용 오차, Redis 조회를 2초당 1회로 제한</li>
+     * </ul>
      */
     @Bean("caffeineCacheManager")
     public CacheManager caffeineCacheManager() {
-        CaffeineCacheManager manager = new CaffeineCacheManager(MATCH_SNAPSHOT_CACHE);
-        manager.setCaffeine(
+        CaffeineCache matchSnapshotCache = new CaffeineCache(
+                MATCH_SNAPSHOT_CACHE,
                 Caffeine.newBuilder()
-                        .maximumSize(1_000)          // 경기 1,000개 상한
+                        .maximumSize(1_000)
                         .expireAfterWrite(Duration.ofMinutes(5))
-                        .recordStats()               // 캐시 히트율 모니터링
+                        .recordStats()
+                        .build()
         );
+
+        CaffeineCache seatRemainingCache = new CaffeineCache(
+                SEAT_REMAINING_CACHE,
+                Caffeine.newBuilder()
+                        .maximumSize(1_000)                    // 경기 1,000개 상한
+                        .expireAfterWrite(Duration.ofSeconds(2)) // 표시용 허용 오차 2초
+                        .recordStats()
+                        .build()
+        );
+
+        SimpleCacheManager manager = new SimpleCacheManager();
+        manager.setCaches(List.of(matchSnapshotCache, seatRemainingCache));
         return manager;
     }
 
     // ── L2: Redis ─────────────────────────────────────────────────────────────
 
     /**
-     * Redis L2 캐시 매니저.
+     * Redis L2 캐시 매니저 ({@code match-snapshot} 전용).
      *
      * <p>TTL 60분: {@code @CacheEvict} 가 정확성을 보장하므로 TTL 은 안전망.
-     * Redis 장애 시 {@link RedisCacheErrorHandler} 가 오류를 무시하여 L1 으로 폴백.
+     * {@code seat-remaining} 은 Redis 가 원본이므로 이 매니저에 등록하지 않는다.
      */
     @Bean("redisCacheManager")
     public CacheManager redisCacheManager(RedisConnectionFactory factory) {
@@ -99,17 +145,18 @@ public class MatchCacheConfig implements CachingConfigurer {
         return RedisCacheManager.builder(factory)
                 .cacheDefaults(config)
                 .withCacheConfiguration(MATCH_SNAPSHOT_CACHE, config)
+                // seat-remaining 은 Redis 원본이므로 L2 캐시 미등록
                 .build();
     }
 
-    // ── Composite: L1 → L2 순서 조회 ─────────────────────────────────────────
+    // ── Composite: L1 → L2 순서 조회 (match-snapshot 전용) ───────────────────
 
     /**
      * {@link CompositeCacheManager}: L1(Caffeine) → L2(Redis) 순서로 조회.
      *
-     * <p>Spring {@code @Cacheable} 은 이 매니저를 사용한다.
-     * L1 히트 시 L2 조회 생략 → Redis 네트워크 왕복 0회.
-     * L1 미스 → L2 조회 → 히트 시 L1 에도 자동 저장.
+     * <p>{@code match-snapshot} 에만 사용한다.
+     * {@code seat-remaining} 은 {@code @Cacheable(cacheManager = "caffeineCacheManager")} 로
+     * 이 매니저를 우회하여 Caffeine 전용으로 동작한다.
      */
     @Bean
     public CacheManager cacheManager(
@@ -120,7 +167,7 @@ public class MatchCacheConfig implements CachingConfigurer {
                 caffeineCacheManager,
                 redisCacheManager
         );
-        composite.setFallbackToNoOpCache(false); // 캐시 미스 시 DB 조회 보장
+        composite.setFallbackToNoOpCache(false);
         return composite;
     }
 
@@ -137,22 +184,22 @@ public class MatchCacheConfig implements CachingConfigurer {
         return new SimpleCacheErrorHandler() {
             @Override
             public void handleCacheGetError(RuntimeException e, Cache cache, Object key) {
-                log.warn("[Cache] Redis GET 실패 — cache={}, key={}, 원인={}", cache.getName(), key, e.getMessage());
+                log.warn("[Cache] GET 실패 — cache={}, key={}, 원인={}", cache.getName(), key, e.getMessage());
             }
 
             @Override
             public void handleCachePutError(RuntimeException e, Cache cache, Object key, Object value) {
-                log.warn("[Cache] Redis PUT 실패 — cache={}, key={}, 원인={}", cache.getName(), key, e.getMessage());
+                log.warn("[Cache] PUT 실패 — cache={}, key={}, 원인={}", cache.getName(), key, e.getMessage());
             }
 
             @Override
             public void handleCacheEvictError(RuntimeException e, Cache cache, Object key) {
-                log.warn("[Cache] Redis EVICT 실패 — cache={}, key={}, 원인={}", cache.getName(), key, e.getMessage());
+                log.warn("[Cache] EVICT 실패 — cache={}, key={}, 원인={}", cache.getName(), key, e.getMessage());
             }
 
             @Override
             public void handleCacheClearError(RuntimeException e, Cache cache) {
-                log.warn("[Cache] Redis CLEAR 실패 — cache={}, 원인={}", cache.getName(), e.getMessage());
+                log.warn("[Cache] CLEAR 실패 — cache={}, 원인={}", cache.getName(), e.getMessage());
             }
         };
     }

--- a/src/main/java/org/ticketing/match/infrastructure/config/MatchCacheConfig.java
+++ b/src/main/java/org/ticketing/match/infrastructure/config/MatchCacheConfig.java
@@ -178,8 +178,12 @@ public class MatchCacheConfig implements CachingConfigurer {
      *
      * <p>기본 {@link SimpleCacheErrorHandler} 는 예외를 그대로 전파하여 서비스 장애로 이어진다.
      * 이 핸들러는 Redis 오류를 WARN 로그로만 기록하고 계속 진행한다.
+     *
+     * <p>{@link CachingConfigurer} 구현체의 메서드는 Spring 캐시 인프라가 인터페이스를 통해
+     * 직접 호출하므로 {@code @Bean} 등록이 필요 없다.
+     * {@code @Bean}을 붙이면 공통 모듈 {@code KafkaConfig.errorHandler()} 와 빈 이름 충돌이 발생한다.
      */
-    @Bean
+    @Override
     public CacheErrorHandler errorHandler() {
         return new SimpleCacheErrorHandler() {
             @Override

--- a/src/main/java/org/ticketing/match/infrastructure/config/MatchCacheConfig.java
+++ b/src/main/java/org/ticketing/match/infrastructure/config/MatchCacheConfig.java
@@ -15,6 +15,7 @@ import org.springframework.cache.interceptor.SimpleCacheErrorHandler;
 import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -159,6 +160,7 @@ public class MatchCacheConfig implements CachingConfigurer {
      * 이 매니저를 우회하여 Caffeine 전용으로 동작한다.
      */
     @Bean
+    @Primary
     public CacheManager cacheManager(
             CacheManager caffeineCacheManager,
             CacheManager redisCacheManager

--- a/src/main/java/org/ticketing/match/infrastructure/config/MatchCacheConfig.java
+++ b/src/main/java/org/ticketing/match/infrastructure/config/MatchCacheConfig.java
@@ -4,13 +4,13 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import java.time.Duration;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CachingConfigurer;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCache;
 import org.springframework.cache.interceptor.CacheErrorHandler;
-import org.springframework.cache.support.CompositeCacheManager;
 import org.springframework.cache.interceptor.SimpleCacheErrorHandler;
 import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
@@ -30,31 +30,32 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
  * <pre>
  *   match-snapshot  : Match + ZonePolicy 정적 구조 데이터
  *                     L1(Caffeine 5분) → L2(Redis 60분) → DB(fetch join)
+ *                     {@link TwoLevelCache} 가 L1 미스 시 L2 를 실제로 조회한다.
  *
  *   seat-remaining  : 구역별 잔여 좌석 수. L1(Caffeine 2초) → Redis(원본) 구조.
  *                     {@code @Cacheable(sync=true)} + {@code expireAfterWrite(2s)} 로 stampede 방지.
  *                     Redis 가 원본이므로 L2 Redis 캐시 미등록.
  * </pre>
  *
- * <h3>Caffeine 계층 구조 (match-snapshot)</h3>
+ * <h3>read-through 흐름 (match-snapshot)</h3>
  * <pre>
- *   요청 → Caffeine (L1, JVM 메모리, ~0ms)
- *            ↓ miss
- *          Redis (L2, 네트워크 캐시, ~1ms)
- *            ↓ miss
- *          DB (fetch join, ~10ms)
+ *   요청 → TwoLevelCache
+ *            ├─ L1(Caffeine) 히트 → 즉시 반환 (~0ms)
+ *            ├─ L1 미스 + L2(Redis) 히트 → L1 역적재 후 반환 (~1ms)
+ *            └─ L1·L2 모두 미스 → DB fetch join → L2 저장 → L1 저장 (~10ms)
  * </pre>
  *
  * <h3>Redis 장애 시 동작 (match-snapshot)</h3>
  * <ul>
- *   <li>Caffeine L1 히트 → Redis 없이도 서비스 유지.</li>
- *   <li>Caffeine L1 미스 → DB 직접 조회 (Redis 기록 생략).</li>
+ *   <li>L1 히트 → Redis 없이도 서비스 유지.</li>
+ *   <li>L1 미스 → {@link TwoLevelCache} 내 L2 예외를 catch 후 DB 직접 조회.</li>
  *   <li>Redis 복구 후 → 다음 캐시 미스 시 Redis 에 자동 재적재.</li>
  * </ul>
  *
- * <h3>Cache Stampede / Thundering Herd 방지 (match-snapshot)</h3>
+ * <h3>Cache Stampede 방지 (match-snapshot)</h3>
  * <ul>
  *   <li>Caffeine {@code computeIfAbsent} + {@code @Cacheable(sync=true)} 로 단일 로더 보장.</li>
+ *   <li>단일 로더 내부에서 L2 를 먼저 확인하므로 DB 부하를 최소화한다.</li>
  * </ul>
  */
 @Slf4j
@@ -75,6 +76,9 @@ public class MatchCacheConfig implements CachingConfigurer {
      *   <li>{@code seat-remaining}: TTL 2초 — reservation-service 의 Redis DECR/INCR 이 원본.
      *       {@code @Cacheable(sync=true)} 로 stampede 방지. Redis L2 미등록(원본이 Redis 이므로).</li>
      * </ul>
+     *
+     * <p>이 빈은 {@link org.ticketing.match.application.service.MatchSnapshotCacheService#evict}
+     * 에서 L1 직접 evict 시에도 사용된다.
      */
     @Bean("caffeineCacheManager")
     public CacheManager caffeineCacheManager() {
@@ -108,6 +112,9 @@ public class MatchCacheConfig implements CachingConfigurer {
      *
      * <p>TTL 60분: {@code @CacheEvict} 가 정확성을 보장하므로 TTL 은 안전망.
      * {@code seat-remaining} 은 Redis 가 원본이므로 이 매니저에 등록하지 않는다.
+     *
+     * <p>이 빈은 {@link org.ticketing.match.application.service.MatchSnapshotCacheService#evict}
+     * 에서 L2 직접 evict 시에도 사용된다.
      */
     @Bean("redisCacheManager")
     public CacheManager redisCacheManager(RedisConnectionFactory factory) {
@@ -129,25 +136,35 @@ public class MatchCacheConfig implements CachingConfigurer {
                 .build();
     }
 
-    // ── Composite: L1 → L2 순서 조회 (match-snapshot 전용) ───────────────────
+    // ── Primary: TwoLevelCache(match-snapshot) + Caffeine(seat-remaining) ────
 
     /**
-     * {@link CompositeCacheManager}: L1(Caffeine) → L2(Redis) 순서로 조회.
+     * 애플리케이션 전반에서 사용하는 Primary {@link CacheManager}.
      *
-     * <p>{@code match-snapshot} 전용. L1 미스 시 L2(Redis) 에서 자동으로 값을 조회한다.
+     * <ul>
+     *   <li>{@code match-snapshot}: {@link TwoLevelCache} — L1(Caffeine) → L2(Redis) 실제 read-through.</li>
+     *   <li>{@code seat-remaining}: {@link CaffeineCache} — L1 전용 (Redis 가 원본).</li>
+     * </ul>
+     *
+     * <p>{@link TwoLevelCache} 는 L1·L2 의 실제 {@link Cache} 인스턴스를 공유하므로,
+     * {@link org.ticketing.match.application.service.MatchSnapshotCacheService#evict} 에서
+     * 각 매니저를 통해 직접 evict 하는 경우에도 동일한 캐시 객체가 무효화된다.
      */
     @Bean
     @Primary
     public CacheManager cacheManager(
-            CacheManager caffeineCacheManager,
-            CacheManager redisCacheManager
+            @Qualifier("caffeineCacheManager") CacheManager caffeineCacheManager,
+            @Qualifier("redisCacheManager") CacheManager redisCacheManager
     ) {
-        CompositeCacheManager composite = new CompositeCacheManager(
-                caffeineCacheManager,
-                redisCacheManager
-        );
-        composite.setFallbackToNoOpCache(false);
-        return composite;
+        Cache caffeineSnapshot = caffeineCacheManager.getCache(MATCH_SNAPSHOT_CACHE);
+        Cache redisSnapshot    = redisCacheManager.getCache(MATCH_SNAPSHOT_CACHE);
+        Cache twoLevelSnapshot = new TwoLevelCache(MATCH_SNAPSHOT_CACHE, caffeineSnapshot, redisSnapshot);
+
+        Cache caffeineRemaining = caffeineCacheManager.getCache(SEAT_REMAINING_CACHE);
+
+        SimpleCacheManager manager = new SimpleCacheManager();
+        manager.setCaches(List.of(twoLevelSnapshot, caffeineRemaining));
+        return manager;
     }
 
     // ── Redis 오류 핸들러 ─────────────────────────────────────────────────────
@@ -157,6 +174,9 @@ public class MatchCacheConfig implements CachingConfigurer {
      *
      * <p>기본 {@link SimpleCacheErrorHandler} 는 예외를 그대로 전파하여 서비스 장애로 이어진다.
      * 이 핸들러는 Redis 오류를 WARN 로그로만 기록하고 계속 진행한다.
+     *
+     * <p>{@link TwoLevelCache} 내부의 L2 호출은 별도로 try-catch 처리되므로
+     * 이 핸들러는 {@code @Cacheable} AOP 경계에서 발생하는 오류를 추가로 방어한다.
      *
      * <p>{@link CachingConfigurer} 구현체의 메서드는 Spring 캐시 인프라가 인터페이스를 통해
      * 직접 호출하므로 {@code @Bean} 등록이 필요 없다.

--- a/src/main/java/org/ticketing/match/infrastructure/config/MatchCacheConfig.java
+++ b/src/main/java/org/ticketing/match/infrastructure/config/MatchCacheConfig.java
@@ -11,7 +11,7 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCache;
 import org.springframework.cache.interceptor.CacheErrorHandler;
 import org.springframework.cache.support.CompositeCacheManager;
-import org.springframework.cache.support.SimpleCacheErrorHandler;
+import org.springframework.cache.interceptor.SimpleCacheErrorHandler;
 import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/org/ticketing/match/infrastructure/config/TwoLevelCache.java
+++ b/src/main/java/org/ticketing/match/infrastructure/config/TwoLevelCache.java
@@ -1,0 +1,173 @@
+package org.ticketing.match.infrastructure.config;
+
+import java.util.concurrent.Callable;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+
+/**
+ * L1(Caffeine) → L2(Redis) 2계층 읽기 투명(read-through) {@link Cache} 구현체.
+ *
+ * <h3>읽기 전략</h3>
+ * <pre>
+ *   get(key)
+ *     ├─ L1 히트 → 즉시 반환 (~0ms)
+ *     ├─ L1 미스 + L2 히트 → L1 역적재 후 반환 (~1ms)
+ *     └─ L1·L2 모두 미스 → null 반환 → {@code @Cacheable} 이 DB 조회 후 put() 호출
+ * </pre>
+ *
+ * <h3>get(key, callable) — {@code sync=true} 경로</h3>
+ * <p>L1(Caffeine) 의 {@code computeIfAbsent} 로 JVM 내 단일 로더를 보장한다.
+ * 로더 내부에서 L2(Redis) 를 먼저 확인하여 L2 히트 시 DB 호출을 생략한다.
+ *
+ * <h3>쓰기·무효화</h3>
+ * <p>{@code put} / {@code evict} / {@code clear} 는 L1·L2 양쪽에 동시 적용된다.
+ *
+ * <h3>Redis 장애 내성</h3>
+ * <p>L2 작업 중 예외 발생 시 WARN 로그 후 L1 만으로 서비스를 계속 유지한다.
+ */
+@Slf4j
+public class TwoLevelCache implements Cache {
+
+    private final String name;
+    private final Cache l1;   // Caffeine
+    private final Cache l2;   // Redis
+
+    public TwoLevelCache(String name, Cache l1, Cache l2) {
+        this.name = name;
+        this.l1   = l1;
+        this.l2   = l2;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Object getNativeCache() {
+        return this;
+    }
+
+    // ── 읽기 ─────────────────────────────────────────────────────────────────
+
+    /**
+     * L1 → L2 순서로 조회한다.
+     * L2 히트 시 L1 에 역적재(back-fill)하여 이후 요청은 L1 에서 처리된다.
+     */
+    @Override
+    public ValueWrapper get(Object key) {
+        ValueWrapper l1Val = l1.get(key);
+        if (l1Val != null) {
+            return l1Val;
+        }
+
+        ValueWrapper l2Val = getFromL2(key);
+        if (l2Val != null) {
+            l1.put(key, l2Val.get());   // L1 역적재
+        }
+        return l2Val;
+    }
+
+    @Override
+    public <T> T get(Object key, Class<T> type) {
+        T l1Val = l1.get(key, type);
+        if (l1Val != null) {
+            return l1Val;
+        }
+
+        T l2Val = getFromL2(key, type);
+        if (l2Val != null) {
+            l1.put(key, l2Val);         // L1 역적재
+        }
+        return l2Val;
+    }
+
+    /**
+     * {@code @Cacheable(sync = true)} 경로.
+     *
+     * <p>L1(Caffeine) 의 {@code computeIfAbsent} 에 위임하여 JVM 내 단일 로더를 보장한다.
+     * 로더 내부에서 L2 를 먼저 확인하고, L2 히트 시 {@code valueLoader}(DB) 를 건너뛴다.
+     * L2 미스 시에만 DB 를 조회하고 L2 에 적재한다.
+     *
+     * <pre>
+     *   단일 로더(L1.computeIfAbsent)
+     *     ├─ L2 히트 → L2 값 반환 (DB 호출 없음)
+     *     └─ L2 미스 → DB 조회 → L2 저장 → L1 저장
+     * </pre>
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T get(Object key, Callable<T> valueLoader) {
+        return (T) l1.get(key, () -> {
+            // 단일 로더 내부: L2 먼저 확인
+            ValueWrapper l2Wrapper = getFromL2(key);
+            if (l2Wrapper != null) {
+                return l2Wrapper.get();          // DB 호출 생략
+            }
+            // L2 미스 → DB 조회 → L2 저장
+            T value = valueLoader.call();
+            putToL2(key, value);
+            return value;
+        });
+    }
+
+    // ── 쓰기 ─────────────────────────────────────────────────────────────────
+
+    @Override
+    public void put(Object key, Object value) {
+        l1.put(key, value);
+        putToL2(key, value);
+    }
+
+    @Override
+    public void evict(Object key) {
+        l1.evict(key);
+        evictFromL2(key);
+    }
+
+    @Override
+    public void clear() {
+        l1.clear();
+        try {
+            l2.clear();
+        } catch (RuntimeException e) {
+            log.warn("[TwoLevelCache] L2 CLEAR 실패 — cache={}, 원인={}", name, e.getMessage());
+        }
+    }
+
+    // ── L2 헬퍼 (Redis 장애 내성) ─────────────────────────────────────────────
+
+    private ValueWrapper getFromL2(Object key) {
+        try {
+            return l2.get(key);
+        } catch (RuntimeException e) {
+            log.warn("[TwoLevelCache] L2 GET 실패 — cache={}, key={}, 원인={}", name, key, e.getMessage());
+            return null;
+        }
+    }
+
+    private <T> T getFromL2(Object key, Class<T> type) {
+        try {
+            return l2.get(key, type);
+        } catch (RuntimeException e) {
+            log.warn("[TwoLevelCache] L2 GET 실패 — cache={}, key={}, 원인={}", name, key, e.getMessage());
+            return null;
+        }
+    }
+
+    private void putToL2(Object key, Object value) {
+        try {
+            l2.put(key, value);
+        } catch (RuntimeException e) {
+            log.warn("[TwoLevelCache] L2 PUT 실패 — cache={}, key={}, 원인={}", name, key, e.getMessage());
+        }
+    }
+
+    private void evictFromL2(Object key) {
+        try {
+            l2.evict(key);
+        } catch (RuntimeException e) {
+            log.warn("[TwoLevelCache] L2 EVICT 실패 — cache={}, key={}, 원인={}", name, key, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/ticketing/match/infrastructure/persistence/JpaMatchRepository.java
+++ b/src/main/java/org/ticketing/match/infrastructure/persistence/JpaMatchRepository.java
@@ -16,6 +16,6 @@ public interface JpaMatchRepository extends JpaRepository<Match, UUID> {
      * ZonePolicy 를 즉시 로딩(fetch join)해 N+1 쿼리를 방지한다.
      * MatchSnapshotCacheService 의 캐시 미스 시 단 1회 호출된다.
      */
-    @Query("select m from Match m join fetch m.zonePolicies where m.id = :id and m.deletedAt is null")
+    @Query("select distinct m from Match m left join fetch m.zonePolicies where m.id = :id and m.deletedAt is null")
     Optional<Match> findActiveByIdWithPolicies(@Param("id") UUID id);
 }

--- a/src/main/java/org/ticketing/match/infrastructure/persistence/JpaMatchRepository.java
+++ b/src/main/java/org/ticketing/match/infrastructure/persistence/JpaMatchRepository.java
@@ -11,4 +11,11 @@ public interface JpaMatchRepository extends JpaRepository<Match, UUID> {
 
     @Query("select m from Match m where m.id = :id and m.deletedAt is null")
     Optional<Match> findActiveById(@Param("id") UUID id);
+
+    /**
+     * ZonePolicy 를 즉시 로딩(fetch join)해 N+1 쿼리를 방지한다.
+     * MatchSnapshotCacheService 의 캐시 미스 시 단 1회 호출된다.
+     */
+    @Query("select m from Match m join fetch m.zonePolicies where m.id = :id and m.deletedAt is null")
+    Optional<Match> findActiveByIdWithPolicies(@Param("id") UUID id);
 }

--- a/src/main/java/org/ticketing/match/infrastructure/persistence/MatchRepositoryImpl.java
+++ b/src/main/java/org/ticketing/match/infrastructure/persistence/MatchRepositoryImpl.java
@@ -55,4 +55,9 @@ public class MatchRepositoryImpl implements MatchRepository {
     public Optional<Match> findActiveById(UUID id) {
         return jpaMatchRepository.findActiveById(id);
     }
+
+    @Override
+    public Optional<Match> findActiveByIdWithPolicies(UUID id) {
+        return jpaMatchRepository.findActiveByIdWithPolicies(id);
+    }
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -29,6 +29,13 @@ spring:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
+      lettuce:
+        pool:
+          enabled: true
+          max-active: 100
+          max-idle: 20
+          min-idle: 5
+          max-wait: 500ms
 
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}


### PR DESCRIPTION
📎 관련 이슈

close #21 
<html>
<body>
<!--StartFragment--><h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">📌 작업 내용</h3>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>캐시 도입 (match-service)</strong></p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">MatchCacheConfig</code>: Caffeine L1 + Redis L2 <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">CompositeCacheManager</code> 구성, Redis 장애 시 WARN 로그 후 폴백하는 <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">CacheErrorHandler</code> 추가</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">MatchSnapshotCacheService</code>: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">@Cacheable(sync=true)</code> 적용으로 MatchSnapshot DB 조회 캐싱 및 Cache Stampede 방지, L1(Caffeine)·L2(Redis) 양쪽 동시 evict 구현</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">SeatAvailabilityCacheService</code>: 잔여좌석 Caffeine L1 (TTL 2s, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">sync=true</code>) 캐싱으로 Redis 직접 호출 배칭</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">MatchWriteService</code>: APPROVED 전환 시 <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">afterCommit</code> 훅에서 Redis 잔여좌석 초기화 + MatchSnapshot L1·L2 사전 적재</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">RedisSeatAvailabilityRepository</code>: Lua 스크립트로 잔여좌석 원자적 decrement (0 이하 감소 방지)</li>
</ul>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>캐시 구조</strong></p>
<div role="group" aria-label="코드" tabindex="0" class="relative group/copy bg-bg-000/50 border-0.5 border-border-400 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-100"><div class="sticky opacity-0 group-hover/copy:opacity-100 group-focus-within/copy:opacity-100 top-2 py-2 h-12 w-0 float-right"><div class="absolute right-0 h-8 px-2 items-center inline-flex z-10"><button class="inline-flex
  items-center
  justify-center
  relative
  isolate
  shrink-0
  can-focus
  select-none
  disabled:pointer-events-none
  disabled:opacity-50
  disabled:shadow-none
  disabled:drop-shadow-none border-transparent
          transition
          font-base
          duration-300
          ease-[cubic-bezier(0.165,0.85,0.45,1)] h-8 w-8 rounded-md backdrop-blur-md _fill_10ocf_9 _ghost_10ocf_96" type="button" aria-label="클립보드에 복사" data-state="closed"><div class="relative"><div class="transition-all opacity-100 scale-100" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-100 scale-100" aria-hidden="true" style="flex-shrink: 0;"><path d="M12.5 3A1.5 1.5 0 0 1 14 4.5V6h1.5A1.5 1.5 0 0 1 17 7.5v8a1.5 1.5 0 0 1-1.5 1.5h-8A1.5 1.5 0 0 1 6 15.5V14H4.5A1.5 1.5 0 0 1 3 12.5v-8A1.5 1.5 0 0 1 4.5 3zm1.5 9.5a1.5 1.5 0 0 1-1.5 1.5H7v1.5a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-8a.5.5 0 0 0-.5-.5H14zM4.5 4a.5.5 0 0 0-.5.5v8a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-8a.5.5 0 0 0-.5-.5z"></path></svg></div><div class="absolute inset-0 flex items-center justify-center"><div class="transition-all opacity-0 scale-50" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-0 scale-50" aria-hidden="true" style="flex-shrink: 0;"><path d="M15.188 5.11a.5.5 0 0 1 .752.626l-.056.084-7.5 9a.5.5 0 0 1-.738.033l-3.5-3.5-.064-.078a.501.501 0 0 1 .693-.693l.078.064 3.113 3.113 7.15-8.58z"></path></svg></div></div></div></button></div></div><div class="overflow-x-auto"><pre class="code-block__code !my-0 !rounded-lg !text-sm !leading-relaxed p-3.5" style="color: rgb(20, 24, 31); background: transparent; font-family: var(--font-mono);"><code style="color: rgb(20, 24, 31); background: transparent; font-family: var(--font-mono); white-space: pre-wrap;"><span><span>[match-snapshot]  정적 데이터
</span></span><span>  요청 → L1 Caffeine (TTL 5분, ~0ms) → L2 Redis (TTL 60분, ~1ms) → DB (~10ms)
</span><span>
</span><span>[seat-remaining]  동적 데이터 (reservation-service가 Redis 직접 DECR)
</span><span>  요청 → L1 Caffeine (TTL 2s, ~0ms) → Redis 원본 (HGETALL, ~1ms)</span></code></pre></div></div>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>k6 테스트 보강</strong></p>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">ultra-load-test.js</code>: E2E 플로우에 <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">GET /internal/reservations/{id}/detail</code> step 추가 (4-step → 5-step), <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">reservation_detail_failures</code> 카운터 및 임계값 추가, 조회 실패 시 결제 진행 중단</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">remaining-seats-load-test.js</code> 신규 작성: 잔여좌석 조회 1,000 req/s (constant-arrival-rate) + HOLD 러시 500/s (ramping-arrival-rate) 동반 시나리오, 1분 실행</li>
</ul>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">✨ 변경 사항</h3>
<div class="overflow-x-auto w-full px-2 mb-6">
파일 | 유형 | 내용
-- | -- | --
infrastructure/config/MatchCacheConfig.java | 신규 | Caffeine L1 + Redis L2 CompositeCacheManager, CacheErrorHandler
application/service/MatchSnapshotCacheService.java | 신규 | MatchSnapshot @Cacheable(sync=true), L1·L2 dual evict
application/service/SeatAvailabilityCacheService.java | 신규 | 잔여좌석 Caffeine L1 @Cacheable(sync=true, TTL 2s)
application/service/MatchWriteService.java | 수정 | APPROVED afterCommit → Redis 초기화 + 캐시 warm-up
infrastructure/redis/RedisSeatAvailabilityRepository.java | 신규 | Redis Hash 기반 잔여좌석 저장소, Lua 원자적 decrement
domain/repository/SeatAvailabilityRepository.java | 신규 | SeatAvailabilityRepository 도메인 인터페이스
k6/ultra-load-test.js | 수정 | E2E 플로우 /detail step 추가, reservation_detail_failures 카운터
k6/remaining-seats-load-test.js | 신규 | 잔여좌석 1,000 req/s 집중 부하 테스트

</div>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">📝 리뷰 포인트 (선택)</h3>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">CompositeCacheManager.getCache()</code>는 첫 번째 매니저(Caffeine)만 반환하므로 <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">@CacheEvict</code> 단독으로는 Redis L2가 삭제되지 않는다. <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">evict()</code>에서 두 매니저에 각각 직접 evict를 호출하는 방식이 적절한지 확인 요청</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">seat-remaining</code> TTL 2s bimodal 분포: TTL 만료 순간 다수 요청이 Redis를 동시 조회하는 구간에서 tail latency spike 가능성 — TTL 값 조정 또는 <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">refreshAfterWrite</code> 전환 필요 여부 검토 요청 (현재는 <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">refreshAfterWrite</code>가 Lettuce 커넥션 풀을 점유하여 HOLD 지연을 유발하는 것이 실험적으로 확인되어 보류)</li>
<li class="font-claude-response-body whitespace-normal break-words pl-2"><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">sync=true</code>는 단일 인스턴스에서만 Stampede를 완전히 방지한다. 수평 확장 시 인스턴스 수만큼 L2(Redis) 또는 DB 동시 조회 가능 — 현재 단일 인스턴스 환경이므로 문제없으나 확장 시 distributed lock 전략 필요</li>
</ul>
<hr class="border-border-200 border-t-0.5 my-3 mx-1.5">
<h3 class="text-text-100 mt-2 -mb-1 text-base font-bold">🧠 기타 참고 사항</h3><!--EndFragment-->
</body>
</html>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-layer caching system for match and seat availability data.
  * Implemented automatic cache invalidation when match information is updated.
  * Enhanced database connection management with optimized Redis connection pooling configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3s-ticketing/match-service/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->